### PR TITLE
Change image crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ bevy_rapier3d = { version = "0.27", optional = true }
 avian3d = { version = "0.1", optional = true }
 default-struct-builder = "0.5.0"
 float-ord = "0.3"
-image = "0.25"
+image = { version = "0.25", default-features = false }
 indexmap = { version = "2.2", features = ["serde"] }
 itertools = "0.13"
 json = "0.12"


### PR DESCRIPTION
Disable default-features on image crate so that we can dynamically link bevy on linux.