### PR TITLE
Switch lightmap compositing to compute shader

### DIFF
--- a/src/bsp/composite_irradiance_volumes.wgsl
+++ b/src/bsp/composite_irradiance_volumes.wgsl
@@ -26,7 +26,7 @@ fn sample_atlas(input: texture_3d<f32>, animator_idx: u32, coords: vec3u) -> vec
 
 @compute @workgroup_size(4, 4, 4)
 fn main(
-	@builtin(global_invocation_id) invocation_id: vec3<u32>
+	@builtin(global_invocation_id) invocation_id: vec3u,
 ) {
 	var color = vec4f(0, 0, 0, 1);
 

--- a/src/bsp/composite_lightmaps.wgsl
+++ b/src/bsp/composite_lightmaps.wgsl
@@ -17,30 +17,12 @@ struct Animator {
 @group(0) @binding(2) var input_texture_2: texture_2d<f32>;
 @group(0) @binding(3) var input_texture_3: texture_2d<f32>;
 @group(0) @binding(4) var input_texture_mapping: texture_2d<u32>;
-@group(0) @binding(5) var input_sampler: sampler;
-@group(0) @binding(6) var<uniform> animators: array<Animator, MAX_ANIMATORS>;
+@group(0) @binding(5) var<uniform> animators: array<Animator, MAX_ANIMATORS>;
+@group(0) @binding(6) var output: texture_storage_2d<rgba32float, write>;
 
 @group(1) @binding(0) var<uniform> globals: Globals;
 
-struct VertexOutput {
-	@builtin(position) position: vec4f,
-	@location(0) uv: vec2f,
-}
-
-@vertex
-fn vertex(
-	@builtin(vertex_index) vert_idx: u32,
-) -> VertexOutput {
-	// Create a quad
-	var output: VertexOutput;
-	output.uv = vec2f(f32(vert_idx % 2), f32(vert_idx / 2));
-	output.position = vec4f(output.uv * 2 - 1, 0, 1);
-	output.uv.y = 1 - output.uv.y; // TODO this is hacky
-
-	return output;
-}
-
-fn sample_atlas(input: texture_2d<f32>, animator_idx: u32, uv: vec2f) -> vec4f {
+fn sample_atlas(input: texture_2d<f32>, animator_idx: u32, uv: vec2u) -> vec4f {
 	var mul = animators[animator_idx].sequence[u32(globals.time * animators[animator_idx].speed) % animators[animator_idx].sequence_len];
 	if animators[animator_idx].interpolate > 0 {
 		let next = animators[animator_idx].sequence[(u32(globals.time * animators[animator_idx].speed) + 1) % animators[animator_idx].sequence_len];
@@ -49,21 +31,22 @@ fn sample_atlas(input: texture_2d<f32>, animator_idx: u32, uv: vec2f) -> vec4f {
 		mul = mix(mul, next, t);
 	}
 
-	return textureSample(input, input_sampler, uv) * vec4f(mul, 1);
+	return textureLoad(input, uv, 0) * vec4f(mul, 1);
 }
 
-@fragment
-fn fragment(
-	input: VertexOutput,
-) -> @location(0) vec4f {
+@compute @workgroup_size(8, 8, 1)
+fn main(
+	@builtin(global_invocation_id) invocation_id: vec3u,
+) {
 	var color = vec4f(0, 0, 0, 1);
 
-	let mapping: vec4u = textureLoad(input_texture_mapping, vec2u(input.uv * vec2f(textureDimensions(input_texture_mapping))), 0);
+	let coords = invocation_id.xy;
+	let mapping: vec4u = textureLoad(input_texture_mapping, coords % textureDimensions(input_texture_mapping), 0);
 
-	color += sample_atlas(input_texture_0, mapping.x, input.uv);
-	color += sample_atlas(input_texture_1, mapping.y, input.uv);
-	color += sample_atlas(input_texture_2, mapping.z, input.uv);
-	color += sample_atlas(input_texture_3, mapping.w, input.uv);
+	color += sample_atlas(input_texture_0, mapping.x, coords);
+	color += sample_atlas(input_texture_1, mapping.y, coords);
+	color += sample_atlas(input_texture_2, mapping.z, coords);
+	color += sample_atlas(input_texture_3, mapping.w, coords);
 
-	return color;
+	textureStore(output, coords, color);
 }


### PR DESCRIPTION
Makes compositing very *slightly* faster.

Originally, i was going to hold out on this for possible wasm support, but `smol` doesn't support wasm, which i need for asset loading.

In that case, i guess there's no reason not to add it