### PR TITLE
Add function for fetching default game config path

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -191,7 +191,6 @@ Now to access the config from TrenchBroom, at some point in your application, yo
 use bevy::prelude::*;
 use bevy_trenchbroom::prelude::*;
 
-// #[cfg(debug_assertions)]
 // app.add_systems(Startup, write_trenchbroom_config)
 
 fn write_trenchbroom_config(server: Res<TrenchBroomServer>) {
@@ -204,7 +203,7 @@ fn write_trenchbroom_config(server: Res<TrenchBroomServer>) {
 }
 ```
 
-This writes it out every time your app starts in debug mode, but depending on what you want to do, you might want to write it out some other time.
+This writes it out every time your app starts, but depending on what you want to do, you might want to write it out some other time.
 
 After you write it out, you have to use the created game config in TrenchBroom's preferences and set the "Game path" to your project/game folder.
 

--- a/readme.md
+++ b/readme.md
@@ -191,10 +191,11 @@ Now to access the config from TrenchBroom, at some point in your application, yo
 use bevy::prelude::*;
 use bevy_trenchbroom::prelude::*;
 
+// #[cfg(debug_assertions)]
 // app.add_systems(Startup, write_trenchbroom_config)
 
 fn write_trenchbroom_config(server: Res<TrenchBroomServer>) {
-    if let Err(err) = server.config.write_folder("<folder_path>") {
+    if let Err(err) = server.config.write_default_config() {
         error!("Could not write TrenchBroom config: {err}");
     }
 
@@ -203,9 +204,9 @@ fn write_trenchbroom_config(server: Res<TrenchBroomServer>) {
 }
 ```
 
-This writes it out every time your app starts, but depending on what you want to do, you might want to write it out some other time.
+This writes it out every time your app starts in debug mode, but depending on what you want to do, you might want to write it out some other time.
 
-After you write it out, the folder the files need to end up in is your TrenchBroom games configuration folder which you can find the path of [here](https://trenchbroom.github.io/manual/latest/#game_configuration_files), and you have the set the "Game path" to your project/game folder in TrenchBroom preferences.
+After you write it out, you have to use the created game config in TrenchBroom's preferences and set the "Game path" to your project/game folder.
 
 ## Materials and `bevy_materialize`
 

--- a/readme.md
+++ b/readme.md
@@ -195,7 +195,7 @@ use bevy_trenchbroom::prelude::*;
 // app.add_systems(Startup, write_trenchbroom_config)
 
 fn write_trenchbroom_config(server: Res<TrenchBroomServer>) {
-    if let Err(err) = server.config.write_default_config() {
+    if let Err(err) = server.config.write_to_default_folder() {
         error!("Could not write TrenchBroom config: {err}");
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -744,45 +744,19 @@ impl From<&DefaultFaceAttributes> for json::JsonValue {
 	}
 }
 
-/// Error type for errors related to writing the TrenchBroom game config into the default location.
-#[derive(Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum DefaultTrenchBroomConfigPathError {
-	/// The target operating system is not supported.
+	#[error("Unsupported target OS: {0}")]
 	UnsupportedOs(String),
-	/// The home directory was not found.
+	#[error("Home directory not found")]
 	HomeDirNotFound,
-	/// The TrenchBroom user data directory was not found. (e.g. `~/.TrenchBroom` on Unix)
+	#[error("TrenchBroom user data not found at {}. Have you installed TrenchBroom?", .0.display())]
 	UserDataNotFound(PathBuf),
-	/// Failed to create the game config directory. (e.g. `~/.TrenchBroom/games/my_cool_bevy_game` on Unix)
+	#[error("Failed to create game config directory: {0}")]
 	CreateDirError(std::io::Error),
-	/// Failed to write the config to the default location.
-	WriteError {
-		/// The error that occurred.
-		error: std::io::Error,
-		/// The path to the config file that was being written to.
-		path: PathBuf,
-	},
+	#[error("Failed to write config to {}: {error}", path.display())]
+	WriteError { error: std::io::Error, path: PathBuf },
 }
-
-impl std::fmt::Display for DefaultTrenchBroomConfigPathError {
-	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		match self {
-			Self::UnsupportedOs(os) => write!(f, "Unsupported target OS: {os}"),
-			Self::HomeDirNotFound => write!(f, "Home directory not found"),
-			Self::UserDataNotFound(path) => {
-				write!(
-					f,
-					"TrenchBroom user data not found at {}. Have you installed TrenchBroom?",
-					path.display()
-				)
-			}
-			Self::CreateDirError(err) => write!(f, "Failed to create game config directory: {err}"),
-			Self::WriteError { error, path } => write!(f, "Failed to write config to {}: {error}", path.display()),
-		}
-	}
-}
-
-impl std::error::Error for DefaultTrenchBroomConfigPathError {}
 
 impl TrenchBroomConfig {
 	/// Writes the configuration into the [default TrenchBroom game config path].

--- a/src/config.rs
+++ b/src/config.rs
@@ -791,7 +791,7 @@ impl TrenchBroomConfig {
 	///
 	/// [default TrenchBroom game config path]: https://trenchbroom.github.io/manual/latest/#game_configuration_files
 	/// [`write_folder`]: Self::write_folder
-	pub fn write_default_config(&self) -> Result<(), DefaultTrenchBroomConfigPathError> {
+	pub fn write_to_default_folder(&self) -> Result<(), DefaultTrenchBroomConfigPathError> {
 		let path = self.get_default_trenchbroom_game_config_path()?;
 		if let Err(err) = self.write_folder(&path) {
 			return Err(DefaultTrenchBroomConfigPathError::WriteError { error: err, path });
@@ -838,9 +838,9 @@ impl TrenchBroomConfig {
 
 	/// Writes the configuration into a folder, it is your choice when to do this in your application, and where you want to save the config to.
 	///
-	/// If you have a standard TrenchBroom installation, you can use [`write_default_config`] instead to use the default location.
+	/// If you have a standard TrenchBroom installation, you can use [`write_to_default_folder`] instead to use the default location.
 	///
-	/// [`write_default_config`]: Self::write_default_config
+	/// [`write_to_default_folder`]: Self::write_to_default_folder
 	pub fn write_folder(&self, folder: impl AsRef<Path>) -> io::Result<()> {
 		if self.name.is_empty() {
 			return Err(io::Error::new(


### PR DESCRIPTION
Not widely tested yet :)
I wasn't sure whether you preferred a function for directly writing the config into this directory or this function for fetching it. Let me know if you'd like me to add a `write_default_config` function or change the `write_config` function to work like this.