### PR TITLE
Register TrenchBroomGltfRotationFix

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -9,7 +9,7 @@ pub struct UtilPlugin;
 impl Plugin for UtilPlugin {
 	fn build(&self, #[allow(unused)] app: &mut App) {
 		#[cfg(not(feature = "client"))]
-		app.register_type::<Mesh3d>().register_type::<Aabb>();
+		app.register_type::<(Mesh3d, Aabb)>();
 		app.register_type::<TrenchBroomGltfRotationFix>();
 	}
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -10,6 +10,7 @@ impl Plugin for UtilPlugin {
 	fn build(&self, #[allow(unused)] app: &mut App) {
 		#[cfg(not(feature = "client"))]
 		app.register_type::<Mesh3d>().register_type::<Aabb>();
+		app.register_type::<TrenchBroomGltfRotationFix>();
 	}
 }
 
@@ -207,7 +208,8 @@ impl IsSceneWorld for DeferredWorld<'_> {
 /// Put this on an entity to counteract the rotation.
 ///
 /// The rotation counteraction works via `on_add` component hook, so only do this when initially spawning.
-#[derive(Component)]
+#[derive(Component, Reflect, Debug, Default)]
+#[reflect(Component)]
 #[component(on_add = Self::on_add)]
 pub struct TrenchBroomGltfRotationFix;
 impl TrenchBroomGltfRotationFix {


### PR DESCRIPTION
Got a runtime error because I was trying to open a scene with this type and it didn't implement `Reflect`.
Also, extremely tiny refactoring :)

I know, I could have done an early return out of the `Scene` world `on_add` stuff, but I figured adding this can't hurt.