### PR TITLE
Implement writing TrenchBroom preferences

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ ndshape = "0.3.0"
 inventory = { version = "0.3", optional = true }
 strum = { version = "0.27", features = ["derive"] }
 enumflags2.workspace = true
+serde_json = "1.0.140"
 
 [dev-dependencies]
 smol = "2"

--- a/example/bsp_loading/main.rs
+++ b/example/bsp_loading/main.rs
@@ -178,6 +178,7 @@ fn setup_scene(
 fn write_config(#[allow(unused)] server: Res<TrenchBroomServer>) {
 	#[cfg(not(target_family = "wasm"))]
 	{
-		server.config.write_to_default_folder().unwrap();
+		server.config.write_game_config_to_default_directory().unwrap();
+		server.config.add_game_to_preferences_in_default_directory().unwrap();
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -186,7 +186,7 @@ Otherwise, you'll have to call `TrenchBroomConfig::register_class<Class>()` to r
 
 The types themselves will also need to be registered with Bevy, but if `TrenchBroomConfig::register_entity_class_types` is enabled (default), that will also happen automatically.
 
-Now to access the config from TrenchBroom, at some point in your application, you need to call `TrenchBroomConfig::write_folder`. Example:
+Now to access the config from TrenchBroom, at some point in your application, you need to call `TrenchBroomConfig::write_game_config` and `TrenchBroomConfig::write_preferences`. Example:
 
 ```rust
 use bevy::prelude::*;
@@ -195,12 +195,16 @@ use bevy_trenchbroom::prelude::*;
 // app.add_systems(Startup, write_trenchbroom_config)
 
 fn write_trenchbroom_config(server: Res<TrenchBroomServer>) {
-    if let Err(err) = server.config.write_to_default_folder() {
-        error!("Could not write TrenchBroom config: {err}");
+    // This will write <TB folder>/games/example_game/GameConfig.cfg,
+    // and <TB folder>/games/example_game/example_game.fgd
+    if let Err(err) = server.config.write_game_config_to_default_directory() {
+        error!("Could not write TrenchBroom game config: {err}");
     }
 
-    // This will write <TB games folder>/example_game/GameConfig.cfg,
-    // and <TB games folder>/example_game/example_game.fgd
+    // And this will add our game to <TB folder>/Preferences.json
+    if let Err(err) = server.config.write_preferences_to_default_directory() {
+        error!("Could not write TrenchBroom preferences: {err}");
+    }
 }
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -186,7 +186,7 @@ Otherwise, you'll have to call `TrenchBroomConfig::register_class<Class>()` to r
 
 The types themselves will also need to be registered with Bevy, but if `TrenchBroomConfig::register_entity_class_types` is enabled (default), that will also happen automatically.
 
-Now to access the config from TrenchBroom, at some point in your application, you need to call `TrenchBroomConfig::write_game_config` and `TrenchBroomConfig::write_preferences`. Example:
+Now to access the config from TrenchBroom, at some point in your application, you need to call `TrenchBroomConfig::write_game_config` and `TrenchBroomConfig::add_game_to_preferences`. For example:
 
 ```rust
 use bevy::prelude::*;
@@ -202,7 +202,7 @@ fn write_trenchbroom_config(server: Res<TrenchBroomServer>) {
     }
 
     // And this will add our game to <TB folder>/Preferences.json
-    if let Err(err) = server.config.write_preferences_to_default_directory() {
+    if let Err(err) = server.config.add_game_to_preferences_in_default_directory() {
         error!("Could not write TrenchBroom preferences: {err}");
     }
 }

--- a/readme.md
+++ b/readme.md
@@ -210,7 +210,7 @@ fn write_trenchbroom_config(server: Res<TrenchBroomServer>) {
 
 This writes it out every time your app starts, but depending on what you want to do, you might want to write it out some other time.
 
-After you write it out, you have to use the created game config in TrenchBroom's preferences and set the "Game path" to your project/game folder.
+After you write it out, you have to select the created game config in TrenchBroom's preferences when creating a new map.
 
 ## Materials and `bevy_materialize`
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -835,7 +835,7 @@ impl TrenchBroomConfig {
 	pub fn write_preferences_to_default_directory(&self) -> Result<(), DefaultTrenchBroomPreferencesError> {
 		let path = self
 			.get_default_preferences_path()
-			.map_err(|err| DefaultTrenchBroomPreferencesError::UserdataDirError(err))?;
+			.map_err(DefaultTrenchBroomPreferencesError::UserdataDirError)?;
 
 		if !path.exists() {
 			return Err(DefaultTrenchBroomPreferencesError::PreferencesNotFoundError(path));
@@ -880,7 +880,7 @@ impl TrenchBroomConfig {
 	fn get_default_trenchbroom_game_config_path(&self) -> Result<PathBuf, DefaultTrenchBroomGameConfigError> {
 		let trenchbroom_userdata = self
 			.get_default_trenchbroom_userdata_path()
-			.map_err(|err| DefaultTrenchBroomGameConfigError::UserdataDirError(err))?;
+			.map_err(DefaultTrenchBroomGameConfigError::UserdataDirError)?;
 		let trenchbroom_game_config = trenchbroom_userdata.join("games").join(&self.name);
 		Ok(trenchbroom_game_config)
 	}

--- a/src/config.rs
+++ b/src/config.rs
@@ -784,7 +784,7 @@ pub enum DefaultTrenchBroomGameConfigError {
 	WriteError { error: io::Error, path: PathBuf },
 }
 
-/// Errors that can occur when trying to use [`TrenchBroomConfig::write_preferences_to_default_directory`]
+/// Errors that can occur when trying to use [`TrenchBroomConfig::add_game_to_preferences_in_default_directory`]
 #[derive(thiserror::Error, Debug)]
 pub enum DefaultTrenchBroomPreferencesError {
 	#[error(
@@ -832,7 +832,10 @@ impl TrenchBroomConfig {
 		Ok(())
 	}
 
-	pub fn write_preferences_to_default_directory(&self) -> Result<(), DefaultTrenchBroomPreferencesError> {
+	/// Adds the game to the preferences file by using the default TrenchBroom user data directory.
+	///
+	/// If you want to customize the path, use [`add_game_to_preferences`](Self::add_game_to_preferences) instead.
+	pub fn add_game_to_preferences_in_default_directory(&self) -> Result<(), DefaultTrenchBroomPreferencesError> {
 		let path = self
 			.get_default_preferences_path()
 			.map_err(DefaultTrenchBroomPreferencesError::UserdataDirError)?;
@@ -840,7 +843,7 @@ impl TrenchBroomConfig {
 		if !path.exists() {
 			return Err(DefaultTrenchBroomPreferencesError::PreferencesNotFoundError(path));
 		}
-		self.write_preferences(&path)?;
+		self.add_game_to_preferences(&path)?;
 		Ok(())
 	}
 
@@ -885,10 +888,11 @@ impl TrenchBroomConfig {
 		Ok(trenchbroom_game_config)
 	}
 
-	/// Writes the TrenchBroom preferences to a file. It is your choice when to do this in your application, and where you want to save the preferences to.
+	/// Adds the game to the preferences file by using the current directory as the game path.
+	/// It is your choice when to do this in your application, and where the preferences file is located.
 	///
-	/// If you have a standard TrenchBroom installation, you can use [`write_preferences_to_default_directory`](Self::write_preferences_to_default_directory) instead to use the default location.
-	pub fn write_preferences(&self, path: impl AsRef<Path>) -> Result<(), DefaultTrenchBroomPreferencesError> {
+	/// If you have a standard TrenchBroom installation, you can use [`add_game_to_preferences_in_default_directory`](Self::add_game_to_preferences_in_default_directory) instead to use the default location.
+	pub fn add_game_to_preferences(&self, path: impl AsRef<Path>) -> Result<(), DefaultTrenchBroomPreferencesError> {
 		if self.name.is_empty() {
 			return Err(DefaultTrenchBroomPreferencesError::UninitializedError);
 		}

--- a/src/config.rs
+++ b/src/config.rs
@@ -761,35 +761,81 @@ impl From<&DefaultFaceAttributes> for json::JsonValue {
 	}
 }
 
+/// Errors that can occur when getting the [default TrenchBroom game config path](https://trenchbroom.github.io/manual/latest/#game_configuration_files).
+/// Such errors typically occur when TrenchBroom is not installed or installed in a non-standard location.
 #[derive(thiserror::Error, Debug)]
-pub enum DefaultTrenchBroomConfigPathError {
+pub enum DefaultTrenchBroomUserdataDirError {
 	#[error("Unsupported target OS: {0}")]
 	UnsupportedOs(String),
 	#[error("Home directory not found")]
 	HomeDirNotFound,
 	#[error("TrenchBroom user data not found at {}. Have you installed TrenchBroom?", .0.display())]
 	UserDataNotFound(PathBuf),
+}
+
+/// Errors that can occur when trying to use [`TrenchBroomConfig::write_game_config_to_default_directory`]
+#[derive(thiserror::Error, Debug)]
+pub enum DefaultTrenchBroomGameConfigError {
+	#[error("Failed to find TrenchBroom user data directory: {0}")]
+	UserdataDirError(DefaultTrenchBroomUserdataDirError),
 	#[error("Failed to create game config directory: {0}")]
 	CreateDirError(io::Error),
 	#[error("Failed to write config to {}: {error}", path.display())]
 	WriteError { error: io::Error, path: PathBuf },
 }
 
+/// Errors that can occur when trying to use [`TrenchBroomConfig::write_trenchbroom_preferences_to_default_directory`]
+#[derive(thiserror::Error, Debug)]
+pub enum DefaultTrenchBroomPreferencesError {
+	#[error("Failed to find TrenchBroom user data directory: {0}")]
+	UserdataDirError(DefaultTrenchBroomUserdataDirError),
+	#[error("Preferences file not found at {0}")]
+	PreferencesNotFoundError(PathBuf),
+	#[error("Failed to read preferences from {}: {error}", path.display())]
+	ReadError { error: io::Error, path: PathBuf },
+	#[error("Failed to deserialize preferences to JSON from {}: {error}", path.display())]
+	DeserializeError { error: serde_json::Error, path: PathBuf },
+	#[error("Failed to find path to current executable: {error}")]
+	CurrentExeError { error: io::Error },
+	#[error("Failed to convert path {path} to string. Is the path of the current executable not valid UTF-8?", path = path.display())]
+	PathToStringError { path: PathBuf },
+	#[error("Failed to write preferences to {}: {error}", path.display())]
+	WriteError { error: io::Error, path: PathBuf },
+}
+
 impl TrenchBroomConfig {
 	/// Writes the configuration into the [default TrenchBroom game config path](https://trenchbroom.github.io/manual/latest/#game_configuration_files).
 	///
-	/// If you want to customize the path, use [`write_folder`](Self::write_folder) instead.
-	pub fn write_to_default_folder(&self) -> Result<(), DefaultTrenchBroomConfigPathError> {
+	/// If you want to customize the path, use [`write_game_config`](Self::write_game_config) instead.
+	pub fn write_game_config_to_default_directory(&self) -> Result<(), DefaultTrenchBroomGameConfigError> {
 		let path = self.get_default_trenchbroom_game_config_path()?;
-		if let Err(err) = self.write_folder(&path) {
-			return Err(DefaultTrenchBroomConfigPathError::WriteError { error: err, path });
+		if !path.exists() {
+			let err = fs::create_dir_all(&path);
+			if let Err(err) = err {
+				return Err(DefaultTrenchBroomGameConfigError::CreateDirError(err));
+			}
+		}
+
+		if let Err(err) = self.write_game_config(&path) {
+			return Err(DefaultTrenchBroomGameConfigError::WriteError { error: err, path });
 		}
 
 		Ok(())
 	}
 
-	/// Get the [default TrenchBroom game config path](https://trenchbroom.github.io/manual/latest/#game_configuration_files) with a subfolder of [`name`](Self::name).
-	fn get_default_trenchbroom_game_config_path(&self) -> Result<PathBuf, DefaultTrenchBroomConfigPathError> {
+	pub fn write_trenchbroom_preferences_to_default_directory(&self) -> Result<(), DefaultTrenchBroomPreferencesError> {
+		let path = self
+			.get_default_trenchbroom_preferences_path()
+			.map_err(|err| DefaultTrenchBroomPreferencesError::UserdataDirError(err))?;
+
+		if !path.exists() {
+			return Err(DefaultTrenchBroomPreferencesError::PreferencesNotFoundError(path));
+		}
+		self.write_trenchbroom_preferences(&path)?;
+		Ok(())
+	}
+
+	fn get_default_trenchbroom_userdata_path(&self) -> Result<PathBuf, DefaultTrenchBroomUserdataDirError> {
 		let trenchbroom_userdata = if cfg!(target_os = "linux") {
 			#[allow(deprecated)] // No longer deprecated starting from 1.86
 			env::home_dir().map(|path| path.join(".TrenchBroom"))
@@ -799,33 +845,77 @@ impl TrenchBroomConfig {
 			#[allow(deprecated)] // No longer deprecated starting from 1.86
 			env::home_dir().map(|path| path.join("Library").join("Application Support").join("TrenchBroom"))
 		} else {
-			return Err(DefaultTrenchBroomConfigPathError::UnsupportedOs(env::consts::OS.to_string()));
+			return Err(DefaultTrenchBroomUserdataDirError::UnsupportedOs(env::consts::OS.to_string()));
 		};
 
 		let Some(trenchbroom_userdata) = trenchbroom_userdata else {
-			return Err(DefaultTrenchBroomConfigPathError::HomeDirNotFound);
+			return Err(DefaultTrenchBroomUserdataDirError::HomeDirNotFound);
 		};
 
 		if !trenchbroom_userdata.exists() {
-			return Err(DefaultTrenchBroomConfigPathError::UserDataNotFound(trenchbroom_userdata));
+			return Err(DefaultTrenchBroomUserdataDirError::UserDataNotFound(trenchbroom_userdata));
 		}
 
+		Ok(trenchbroom_userdata)
+	}
+
+	/// Gets $TRENCHBROOM_DIR/Preferences.json
+	fn get_default_trenchbroom_preferences_path(&self) -> Result<PathBuf, DefaultTrenchBroomUserdataDirError> {
+		let trenchbroom_userdata = self.get_default_trenchbroom_userdata_path()?;
+		let preferences_path = trenchbroom_userdata.join("Preferences.json");
+
+		Ok(preferences_path)
+	}
+
+	/// Gets $TRENCHBROOM_DIR/games/$NAME
+	fn get_default_trenchbroom_game_config_path(&self) -> Result<PathBuf, DefaultTrenchBroomGameConfigError> {
+		let trenchbroom_userdata = self
+			.get_default_trenchbroom_userdata_path()
+			.map_err(|err| DefaultTrenchBroomGameConfigError::UserdataDirError(err))?;
 		let trenchbroom_game_config = trenchbroom_userdata.join("games").join(&self.name);
-
-		if !trenchbroom_game_config.exists() {
-			let err = fs::create_dir_all(&trenchbroom_game_config);
-			if let Err(err) = err {
-				return Err(DefaultTrenchBroomConfigPathError::CreateDirError(err));
-			}
-		}
-
 		Ok(trenchbroom_game_config)
 	}
 
-	/// Writes the configuration into a folder, it is your choice when to do this in your application, and where you want to save the config to.
+	/// Writes the TrenchBroom preferences to a file. It is your choice when to do this in your application, and where you want to save the preferences to.
 	///
-	/// If you have a standard TrenchBroom installation, you can use [`write_to_default_folder`](Self::write_to_default_folder) instead to use the default location.
-	pub fn write_folder(&self, folder: impl AsRef<Path>) -> io::Result<()> {
+	/// If you have a standard TrenchBroom installation, you can use [`write_trenchbroom_preferences_to_default_directory`](Self::write_trenchbroom_preferences_to_default_directory) instead to use the default location.
+	pub fn write_trenchbroom_preferences(&self, path: impl AsRef<Path>) -> Result<(), DefaultTrenchBroomPreferencesError> {
+		let path = path.as_ref();
+		// read the preferences file as json
+		let preferences = fs::read_to_string(path).map_err(|err| DefaultTrenchBroomPreferencesError::ReadError {
+			error: err,
+			path: path.to_path_buf(),
+		})?;
+
+		let mut preferences: json::JsonValue =
+			serde_json::from_str(&preferences).map_err(|err| DefaultTrenchBroomPreferencesError::DeserializeError {
+				error: err,
+				path: path.to_path_buf(),
+			})?;
+
+		// add the game config to the preferences
+		let key = format!("Games/{}/Path", self.name);
+		let mut current_exe = env::current_exe().map_err(|err| DefaultTrenchBroomPreferencesError::CurrentExeError { error: err })?;
+		current_exe.pop();
+		let value = current_exe;
+		let game_dir = value
+			.to_str()
+			.ok_or_else(|| DefaultTrenchBroomPreferencesError::PathToStringError { path: value })?;
+		preferences.insert(&key, game_dir);
+
+		// write the preferences file back to the same path
+		fs::write(path, preferences.to_string()).map_err(|err| DefaultTrenchBroomPreferencesError::WriteError {
+			error: err,
+			path: path.to_path_buf(),
+		})?;
+
+		Ok(())
+	}
+
+	/// Writes the game configuration into a directory, it is your choice when to do this in your application, and where you want to save the config to.
+	///
+	/// If you have a standard TrenchBroom installation, you can use [`write_game_config_to_default_directory`](Self::write_game_config_to_default_directory) instead to use the default location.
+	pub fn write_game_config(&self, directory: impl AsRef<Path>) -> io::Result<()> {
 		if self.name.is_empty() {
 			return Err(io::Error::other(
 				"Please set a name for your TrenchBroom config. \
@@ -833,7 +923,7 @@ impl TrenchBroomConfig {
 			));
 		}
 
-		let folder = folder.as_ref();
+		let folder = directory.as_ref();
 
 		//////////////////////////////////////////////////////////////////////////////////
 		//// GAME CONFIGURATION && ICON


### PR DESCRIPTION
- Implements #62 
- Renames the game config writing a bit so that the difference between these two methods is clear.
- Uses the current directory as the game path. This is safe, as Bevy AFAIK looks in there for the assets as well.