### PR TITLE
Add class spawn hooks

### DIFF
--- a/example/bsp_loading/main.rs
+++ b/example/bsp_loading/main.rs
@@ -88,7 +88,7 @@ impl Cube {
 #[base(Transform)]
 #[model("models/mushroom.glb")]
 #[size(-4 -4 0, 4 4 16)]
-#[component(on_add = spawn_class_gltf::<Mushroom>)]
+#[spawn_hook(spawn_class_gltf::<Self>)]
 pub struct Mushroom;
 
 #[derive(PointClass, Component, Reflect, SmartDefault)]

--- a/example/map_loading/main.rs
+++ b/example/map_loading/main.rs
@@ -47,7 +47,7 @@ impl Cube {
 #[base(Transform)]
 #[model("models/mushroom.glb")]
 #[size(-4 -4 0, 4 4 16)]
-#[component(on_add = spawn_class_gltf::<Mushroom>)]
+#[spawn_hook(spawn_class_gltf::<Self>)]
 pub struct Mushroom;
 
 // This is a custom light class for parity with bsp_loading, if you don't support bsps, you should use `PointLight` as base class instead.

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -19,11 +19,15 @@ use syn::*;
 /// - `#[classname(<case type>)]` Case type can be something like `PascalCase` or `snake_case`. Default if not specified is `snake_case`.
 /// - `#[classname(<string>)]` When outputted to fgd, use the specified string instead of a classname with case converted via the previous attribute.
 /// - `#[base(<type ...>)]` Adds base classes to inherit.
+/// - `#[spawn_hook(<QuakeClassSpawnFn expression>)]` A custom function to run inside the spawn function of this class. Use for things like spawning models.
 /// - `#[no_register]` Doesn't automatically register even if the `auto_register` feature is enabled.
 ///
 /// # Field attributes
 /// - `#[no_default]` Use on fields you want to output an error if not defined, rather than just being replaced by the field's default value.
-#[proc_macro_derive(PointClass, attributes(model, color, iconsprite, size, classname, base, no_register, no_default))]
+#[proc_macro_derive(
+	PointClass,
+	attributes(model, color, iconsprite, size, classname, base, spawn_hook, no_register, no_default)
+)]
 pub fn point_class_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 	quake_class::class_derive(parse_macro_input!(input as DeriveInput), quake_class::QuakeClassType::Point).into()
 }
@@ -51,7 +55,10 @@ pub fn solid_class_derive(input: proc_macro::TokenStream) -> proc_macro::TokenSt
 /// If the `auto_register` feature is enabled, this will automatically register the type with `bevy_trenchbroom`.
 ///
 /// It has the same attributes as [`PointClass`].
-#[proc_macro_derive(BaseClass, attributes(model, color, iconsprite, size, classname, base, no_register, no_default))]
+#[proc_macro_derive(
+	BaseClass,
+	attributes(model, color, iconsprite, size, classname, base, spawn_hook, no_register, no_default)
+)]
 pub fn base_class_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 	quake_class::class_derive(parse_macro_input!(input as DeriveInput), quake_class::QuakeClassType::Base).into()
 }

--- a/readme.md
+++ b/readme.md
@@ -114,22 +114,19 @@ pub struct FuncIllusionary;
 
 /// A GLTF model with no physics.
 #[derive(PointClass, Component, Reflect)]
-// Here you would probably do a
-// #[component(on_add = "<function>")] to spawn the GLTF scene when
-// this component is added.
-// Make sure to remember that `on_add` is run both in the scene world
-// stored in the map asset, and main world.
-//
-// The utility function `DeferredWorld::is_scene_world` is a
-// handy shorthand to early return if the hook is being run
-// in a scene.
+// Here you would do a
+// #[spawn_hook(<function>)] to spawn the GLTF scene when
+// this entity is spawned in the scene world.
 //
 // Alternatively, you could create a system with a query
 // `Query<&StaticProp, Without<SceneRoot>>`
-// and spawn it through that.
+// and spawn it through that, but .
 //
-// NOTE: If you're using a GLTF model, insert
-// the TrenchBroomGltfRotationFix component when spawning the model.
+// NOTE: If you're using a GLTF model, use
+// the trenchbroom_gltf_rotation_fix function when spawning the model.
+//
+// If your entity has a hardcoded model, you can use a function
+// like `spawn_class_gltf` to do the above automatically.
 #[reflect(Component)]
 #[base(Transform, Visibility)]
 // Sets the in-editor model using TrenchBroom's expression language.
@@ -160,7 +157,7 @@ impl Default for StaticProp {
 
 /// A GLTF model with physics.
 #[derive(PointClass, Component, Reflect)]
-// Here you'd use #[component(on_add = "<function>")] or a system to
+// Here you'd use #[spawn_hook(<function>)], a component hook, or a system to
 // add a RigidBody of your preferred physics engine.
 #[reflect(Component)]
 #[base(StaticProp)]

--- a/src/class/mod.rs
+++ b/src/class/mod.rs
@@ -133,10 +133,13 @@ pub trait QuakeClass: Component + GetTypeRegistration + Sized {
 	fn class_spawn(view: &mut QuakeClassSpawnView) -> anyhow::Result<()>;
 }
 
+/// Function that spawns a [`QuakeClass`] into a scene world. Also used for spawning hooks.
+pub type QuakeClassSpawnFn = fn(&mut QuakeClassSpawnView) -> anyhow::Result<()>;
+
 #[derive(Debug, Clone, Copy)]
 pub struct ErasedQuakeClass {
 	pub info: QuakeClassInfo,
-	pub spawn_fn: fn(&mut QuakeClassSpawnView) -> anyhow::Result<()>,
+	pub spawn_fn: QuakeClassSpawnFn,
 	pub get_type_registration: fn() -> TypeRegistration,
 	pub register_type_dependencies: fn(&mut TypeRegistry),
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -40,7 +40,7 @@ pub use crate::{
 	config::TrenchBroomConfig,
 	geometry::{GeometryProvider, GeometryProviderView},
 	qmap::QuakeMapEntity,
-	util::{IsSceneWorld, TrenchBroomGltfRotationFix},
+	util::{trenchbroom_gltf_rotation_fix, IsSceneWorld},
 	TrenchBroomPlugin, TrenchBroomServer,
 };
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,5 @@
 use bevy::{
-	ecs::{component::ComponentId, world::DeferredWorld},
+	ecs::world::DeferredWorld,
 	image::{ImageAddressMode, ImageSampler, ImageSamplerDescriptor},
 };
 
@@ -204,20 +204,10 @@ impl IsSceneWorld for DeferredWorld<'_> {
 
 /// Band-aid fix for a [TrenchBroom bug](https://github.com/TrenchBroom/TrenchBroom/issues/4447) where GLTF models are rotated be 90 degrees on the Y axis.
 ///
-/// Put this on an entity to counteract the rotation.
-///
-/// The rotation counteraction works via `on_add` component hook, so only do this when initially spawning.
-#[derive(Component)]
-#[component(on_add = Self::on_add)]
-pub struct TrenchBroomGltfRotationFix;
-impl TrenchBroomGltfRotationFix {
-	pub fn on_add(mut world: DeferredWorld, entity: Entity, _: ComponentId) {
-		let mut entity = world.entity_mut(entity);
-		if entity.contains::<TrenchBroomGltfRotationFix>() {
-			if let Some(mut transform) = entity.get_mut::<Transform>() {
-				transform.rotate_local_y(std::f32::consts::PI / 2.);
-			}
-		}
+/// Apply this on an entity to counteract the rotation.
+pub fn trenchbroom_gltf_rotation_fix(entity: &mut EntityWorldMut) {
+	if let Some(mut transform) = entity.get_mut::<Transform>() {
+		transform.rotate_local_y(std::f32::consts::PI / 2.);
 	}
 }
 


### PR DESCRIPTION
A custom function that is run inside the spawn function of a class that you are now able to specify for a derive macro.

This also moves class model spawning functions to this system, using the `LoadContext` supplied to an asset loader to make the map asset itself dependent on anything you load within.

This also also changes `TrenchBroomGltfRotationFix` into a simple function to be used in this system.