### PR TITLE
Fix rotation conversion

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -249,14 +249,16 @@ impl TrenchBroomGltfRotationFixEntityCommandsExt for EntityCommands<'_> {
 	}
 }
 
-fn quake_fwd_to_bevy_fwd() -> Quat {
+/// Rotate from Quake's +X to Bevy's -Z.
+#[inline]
+pub fn quake_fwd_to_bevy_fwd() -> Quat {
 	Quat::from_rotation_y(FRAC_PI_2)
 }
 
 /// `angles` is pitch, yaw, roll. Converts from degrees to radians. `0 0 0` [points east](https://www.gamers.org/dEngine/quake/QDP/qmapspec.html#2.1.1).
 #[inline]
 pub fn angles_to_quat(angles: Vec3) -> Quat {
-	quake_fwd_to_bevy_fwd() * Quat::from_euler(EulerRot::XYZ, angles.x.to_radians(), angles.y.to_radians(), angles.z.to_radians())
+	quake_fwd_to_bevy_fwd() * Quat::from_euler(EulerRot::YXZ, angles.y.to_radians(), angles.x.to_radians(), angles.z.to_radians())
 }
 
 /// `mangle` is yaw, pitch, roll. Converts from degrees to radians. `0 0 0` [points east](https://www.gamers.org/dEngine/quake/QDP/qmapspec.html#2.1.1).
@@ -330,10 +332,5 @@ fn rotation_property_to_quat() {
 	assert_almost_eq!(angles_to_quat(vec3(0., 90., 0.)) * Vec3::X, Vec3::NEG_X, MARGIN);
 	assert_almost_eq!(angles_to_quat(vec3(90., 0., 0.)) * Vec3::X, Vec3::NEG_Z, MARGIN);
 	assert_almost_eq!(angles_to_quat(vec3(0., 0., 90.)) * Vec3::Y, Vec3::Z, MARGIN);
-	assert_almost_eq!(
-		angles_to_quat(vec3(-45., -45., 0.)) * Vec3::X,
-		// A vector pointing in the upper-right corner of a unit cube
-		vec3(1.0, 1.0, -2.0_f32.sqrt()).normalize(),
-		MARGIN
-	);
+	assert_almost_eq!(angles_to_quat(vec3(-45., -45., 0.)) * Vec3::X, vec3(1.0, 0.0, -1.0).normalize(), MARGIN);
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -249,15 +249,14 @@ impl TrenchBroomGltfRotationFixEntityCommandsExt for EntityCommands<'_> {
 	}
 }
 
+fn quake_fwd_to_bevy_fwd() -> Quat {
+	Quat::from_rotation_y(FRAC_PI_2)
+}
+
 /// `angles` is pitch, yaw, roll. Converts from degrees to radians. `0 0 0` [points east](https://www.gamers.org/dEngine/quake/QDP/qmapspec.html#2.1.1).
 #[inline]
 pub fn angles_to_quat(angles: Vec3) -> Quat {
-	Quat::from_euler(
-		EulerRot::XYZ,
-		angles.x.to_radians(),
-		angles.y.to_radians() + FRAC_PI_2, // convert from (forward = X) to (forward = -Z)
-		angles.z.to_radians(),
-	)
+	quake_fwd_to_bevy_fwd() * Quat::from_euler(EulerRot::XYZ, angles.x.to_radians(), angles.y.to_radians(), angles.z.to_radians())
 }
 
 /// `mangle` is yaw, pitch, roll. Converts from degrees to radians. `0 0 0` [points east](https://www.gamers.org/dEngine/quake/QDP/qmapspec.html#2.1.1).
@@ -265,12 +264,7 @@ pub fn angles_to_quat(angles: Vec3) -> Quat {
 /// NOTE: TrenchBroom docs dictate that this function should only be called when the entity classname begins with "light", otherwise "mangle" is a synonym for “angles”.
 #[inline]
 pub fn mangle_to_quat(mangle: Vec3) -> Quat {
-	Quat::from_euler(
-		EulerRot::YXZ,
-		mangle.x.to_radians() + FRAC_PI_2, // convert from (forward = X) to (forward = -Z)
-		mangle.y.to_radians(),
-		mangle.z.to_radians(),
-	)
+	quake_fwd_to_bevy_fwd() * Quat::from_euler(EulerRot::YXZ, mangle.x.to_radians(), mangle.y.to_radians(), mangle.z.to_radians())
 }
 
 /// `angle` is the rotation around the Y axis. Converts from degrees to radians. `0` [points east](https://www.gamers.org/dEngine/quake/QDP/qmapspec.html#2.1.1).
@@ -279,11 +273,12 @@ pub fn mangle_to_quat(mangle: Vec3) -> Quat {
 /// - -2: Down
 #[inline]
 pub fn angle_to_quat(angle: f32) -> Quat {
-	match angle {
-		-1. => Quat::from_rotation_x(FRAC_PI_2),
-		-2. => Quat::from_rotation_x(-FRAC_PI_2),
-		angle => Quat::from_rotation_y(angle.to_radians() + FRAC_PI_2), // convert from (forward = X) to (forward = -Z)
-	}
+	quake_fwd_to_bevy_fwd()
+		* match angle {
+			-1. => Quat::from_rotation_z(FRAC_PI_2),
+			-2. => Quat::from_rotation_z(-FRAC_PI_2),
+			angle => Quat::from_rotation_y(angle.to_radians()),
+		}
 }
 
 pub const QUAKE_LIGHT_TO_LUX_DIVISOR: f32 = 50_000.;
@@ -311,32 +306,34 @@ fn rotation_property_to_quat() {
 	const MARGIN: f32 = 0.0001;
 
 	// angle
-	assert_almost_eq!(angle_to_quat(0.) * Vec3::NEG_Z, Vec3::X, MARGIN);
-	assert_almost_eq!(angle_to_quat(90.) * Vec3::NEG_Z, Vec3::NEG_Z, MARGIN);
+	assert_almost_eq!(angle_to_quat(0.) * Vec3::X, Vec3::NEG_Z, MARGIN);
+	assert_almost_eq!(angle_to_quat(90.) * Vec3::X, Vec3::NEG_X, MARGIN);
 	assert_almost_eq!(angle_to_quat(0.) * Vec3::Y, Vec3::Y, MARGIN);
-	assert_almost_eq!(angle_to_quat(-1.) * Vec3::NEG_Z, Vec3::Y, MARGIN);
-	assert_almost_eq!(angle_to_quat(-2.) * Vec3::NEG_Z, Vec3::NEG_Y, MARGIN);
+	assert_almost_eq!(angle_to_quat(-1.) * Vec3::X, Vec3::Y, MARGIN);
+	assert_almost_eq!(angle_to_quat(-2.) * Vec3::X, Vec3::NEG_Y, MARGIN);
 	assert_almost_eq!(angle_to_quat(-2.) * Vec3::Y, Vec3::NEG_Z, MARGIN);
 
 	// mangle
-	assert_almost_eq!(mangle_to_quat(vec3(0., 0., 0.)) * Vec3::NEG_Z, Vec3::X, MARGIN);
+	assert_almost_eq!(mangle_to_quat(vec3(0., 0., 0.)) * Vec3::X, Vec3::NEG_Z, MARGIN);
 	assert_almost_eq!(mangle_to_quat(vec3(0., 0., 0.)) * Vec3::Y, Vec3::Y, MARGIN);
 
-	assert_almost_eq!(mangle_to_quat(vec3(90., 0., 0.)) * Vec3::NEG_Z, Vec3::NEG_Z, MARGIN);
-	assert_almost_eq!(mangle_to_quat(vec3(0., -90., 0.)) * Vec3::NEG_Z, Vec3::NEG_Y, MARGIN);
-	assert_almost_eq!(mangle_to_quat(vec3(0., 90., 0.)) * Vec3::NEG_Z, Vec3::Y, MARGIN);
+	assert_almost_eq!(mangle_to_quat(vec3(90., 0., 0.)) * Vec3::X, Vec3::NEG_X, MARGIN);
+	assert_almost_eq!(mangle_to_quat(vec3(0., -90., 0.)) * Vec3::X, Vec3::NEG_Z, MARGIN);
+	assert_almost_eq!(mangle_to_quat(vec3(0., 90., 0.)) * Vec3::X, Vec3::NEG_Z, MARGIN);
 	assert_almost_eq!(mangle_to_quat(vec3(0., 0., 90.)) * Vec3::Y, Vec3::Z, MARGIN);
-	// assert_eq!((mangle_to_quat(vec3(45., 45., 0.)) * Vec3::NEG_Z - vec3(1., 1., -1.).normalize()).length(), 0.);
-	// almost 0.17 in precision loss??? how??
-	assert_almost_eq!(mangle_to_quat(vec3(45., 45., 0.)) * Vec3::NEG_Z, vec3(1., 1., -1.).normalize(), 0.2);
+	assert_almost_eq!(mangle_to_quat(vec3(45., 45., 0.)) * Vec3::X, vec3(-1., 0., -1.).normalize(), MARGIN);
 
 	// angles
-	assert_almost_eq!(angles_to_quat(vec3(0., 0., 0.)) * Vec3::NEG_Z, Vec3::X, MARGIN);
+	assert_almost_eq!(angles_to_quat(vec3(0., 0., 0.)) * Vec3::X, Vec3::NEG_Z, MARGIN);
 	assert_almost_eq!(angles_to_quat(vec3(0., 0., 0.)) * Vec3::Y, Vec3::Y, MARGIN);
 
-	assert_almost_eq!(angles_to_quat(vec3(0., 90., 0.)) * Vec3::NEG_Z, Vec3::NEG_Z, MARGIN);
-	assert_almost_eq!(angles_to_quat(vec3(90., 0., 0.)) * Vec3::NEG_Z, Vec3::NEG_Y, MARGIN);
+	assert_almost_eq!(angles_to_quat(vec3(0., 90., 0.)) * Vec3::X, Vec3::NEG_X, MARGIN);
+	assert_almost_eq!(angles_to_quat(vec3(90., 0., 0.)) * Vec3::X, Vec3::NEG_Z, MARGIN);
 	assert_almost_eq!(angles_to_quat(vec3(0., 0., 90.)) * Vec3::Y, Vec3::Z, MARGIN);
-	// Margin adjusted for bogus precision loss
-	assert_almost_eq!(angles_to_quat(vec3(-45., -45., 0.)) * Vec3::NEG_Z, vec3(1., 1., 1.).normalize(), 0.2);
+	assert_almost_eq!(
+		angles_to_quat(vec3(-45., -45., 0.)) * Vec3::X,
+		// A vector pointing in the upper-right corner of a unit cube
+		vec3(1.0, 1.0, -2.0_f32.sqrt()).normalize(),
+		MARGIN
+	);
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -261,12 +261,12 @@ pub fn angles_to_quat(angles: Vec3) -> Quat {
 	quake_fwd_to_bevy_fwd() * Quat::from_euler(EulerRot::YXZ, angles.y.to_radians(), angles.x.to_radians(), angles.z.to_radians())
 }
 
-/// `mangle` is yaw, pitch, roll. Converts from degrees to radians. `0 0 0` [points east](https://www.gamers.org/dEngine/quake/QDP/qmapspec.html#2.1.1).
+/// `mangle` is yaw, negative pitch, roll. Converts from degrees to radians. `0 0 0` [points east](https://www.gamers.org/dEngine/quake/QDP/qmapspec.html#2.1.1).
 ///
 /// NOTE: TrenchBroom docs dictate that this function should only be called when the entity classname begins with "light", otherwise "mangle" is a synonym for “angles”.
 #[inline]
 pub fn mangle_to_quat(mangle: Vec3) -> Quat {
-	quake_fwd_to_bevy_fwd() * Quat::from_euler(EulerRot::YXZ, mangle.x.to_radians(), mangle.y.to_radians(), mangle.z.to_radians())
+	quake_fwd_to_bevy_fwd() * Quat::from_euler(EulerRot::YXZ, mangle.x.to_radians(), -mangle.y.to_radians(), mangle.z.to_radians())
 }
 
 /// `angle` is the rotation around the Y axis. Converts from degrees to radians. `0` [points east](https://www.gamers.org/dEngine/quake/QDP/qmapspec.html#2.1.1).

--- a/src/util.rs
+++ b/src/util.rs
@@ -261,7 +261,7 @@ pub fn angles_to_quat(angles: Vec3) -> Quat {
 	let pitch = angles.x.to_radians();
 	let yaw = angles.y.to_radians();
 	let roll = angles.z.to_radians();
-	quake_fwd_to_bevy_fwd() * Quat::from_euler(EulerRot::ZXYEx, roll, pitch, yaw)
+	quake_fwd_to_bevy_fwd() * Quat::from_euler(EulerRot::YXZ, yaw, pitch, roll)
 }
 
 /// `mangle` is yaw, negative pitch, roll. Converts from degrees to radians. `0 0 0` [points east](https://www.gamers.org/dEngine/quake/QDP/qmapspec.html#2.1.1).
@@ -272,7 +272,7 @@ pub fn mangle_to_quat(mangle: Vec3) -> Quat {
 	let yaw = mangle.x.to_radians();
 	let pitch = -mangle.y.to_radians();
 	let roll = mangle.z.to_radians();
-	quake_fwd_to_bevy_fwd() * Quat::from_euler(EulerRot::ZXYEx, roll, pitch, yaw)
+	quake_fwd_to_bevy_fwd() * Quat::from_euler(EulerRot::YXZ, yaw, pitch, roll)
 }
 
 /// `angle` is the rotation around the Y axis. Converts from degrees to radians. `0` [points east](https://www.gamers.org/dEngine/quake/QDP/qmapspec.html#2.1.1).

--- a/src/util.rs
+++ b/src/util.rs
@@ -258,7 +258,10 @@ pub fn quake_fwd_to_bevy_fwd() -> Quat {
 /// `angles` is pitch, yaw, roll. Converts from degrees to radians. `0 0 0` [points east](https://www.gamers.org/dEngine/quake/QDP/qmapspec.html#2.1.1).
 #[inline]
 pub fn angles_to_quat(angles: Vec3) -> Quat {
-	quake_fwd_to_bevy_fwd() * Quat::from_euler(EulerRot::YXZ, angles.y.to_radians(), angles.x.to_radians(), angles.z.to_radians())
+	let pitch = angles.x.to_radians();
+	let yaw = angles.y.to_radians();
+	let roll = angles.z.to_radians();
+	quake_fwd_to_bevy_fwd() * Quat::from_euler(EulerRot::ZXYEx, roll, pitch, yaw)
 }
 
 /// `mangle` is yaw, negative pitch, roll. Converts from degrees to radians. `0 0 0` [points east](https://www.gamers.org/dEngine/quake/QDP/qmapspec.html#2.1.1).
@@ -266,7 +269,10 @@ pub fn angles_to_quat(angles: Vec3) -> Quat {
 /// NOTE: TrenchBroom docs dictate that this function should only be called when the entity classname begins with "light", otherwise "mangle" is a synonym for “angles”.
 #[inline]
 pub fn mangle_to_quat(mangle: Vec3) -> Quat {
-	quake_fwd_to_bevy_fwd() * Quat::from_euler(EulerRot::YXZ, mangle.x.to_radians(), -mangle.y.to_radians(), mangle.z.to_radians())
+	let yaw = mangle.x.to_radians();
+	let pitch = -mangle.y.to_radians();
+	let roll = mangle.z.to_radians();
+	quake_fwd_to_bevy_fwd() * Quat::from_euler(EulerRot::ZXYEx, roll, pitch, yaw)
 }
 
 /// `angle` is the rotation around the Y axis. Converts from degrees to radians. `0` [points east](https://www.gamers.org/dEngine/quake/QDP/qmapspec.html#2.1.1).

--- a/src/util.rs
+++ b/src/util.rs
@@ -252,10 +252,12 @@ impl TrenchBroomGltfRotationFixEntityCommandsExt for EntityCommands<'_> {
 /// `angles` is pitch, yaw, roll. Converts from degrees to radians. `0 0 0` [points east](https://www.gamers.org/dEngine/quake/QDP/qmapspec.html#2.1.1).
 #[inline]
 pub fn angles_to_quat(angles: Vec3) -> Quat {
-	let yaw = Quat::from_rotation_y((angles.y - 90.).to_radians()); // We must be east-pointing
-	let pitch = Quat::from_rotation_x(-angles.x.to_radians());
-	let roll = Quat::from_rotation_z(-angles.z.to_radians());
-	yaw * pitch * roll
+	Quat::from_euler(
+		EulerRot::XYZ,
+		angles.x.to_radians(),
+		angles.y.to_radians() + FRAC_PI_2, // convert from (forward = X) to (forward = -Z)
+		angles.z.to_radians(),
+	)
 }
 
 /// `mangle` is yaw, pitch, roll. Converts from degrees to radians. `0 0 0` [points east](https://www.gamers.org/dEngine/quake/QDP/qmapspec.html#2.1.1).
@@ -263,10 +265,12 @@ pub fn angles_to_quat(angles: Vec3) -> Quat {
 /// NOTE: TrenchBroom docs dictate that this function should only be called when the entity classname begins with "light", otherwise "mangle" is a synonym for “angles”.
 #[inline]
 pub fn mangle_to_quat(mangle: Vec3) -> Quat {
-	let yaw = Quat::from_rotation_y((mangle.x - 90.).to_radians()); // We must be east-pointing
-	let pitch = Quat::from_rotation_x(mangle.y.to_radians());
-	let roll = Quat::from_rotation_z(-mangle.z.to_radians());
-	yaw * pitch * roll
+	Quat::from_euler(
+		EulerRot::YXZ,
+		mangle.x.to_radians() + FRAC_PI_2, // convert from (forward = X) to (forward = -Z)
+		mangle.y.to_radians(),
+		mangle.z.to_radians(),
+	)
 }
 
 /// `angle` is the rotation around the Y axis. Converts from degrees to radians. `0` [points east](https://www.gamers.org/dEngine/quake/QDP/qmapspec.html#2.1.1).
@@ -278,7 +282,7 @@ pub fn angle_to_quat(angle: f32) -> Quat {
 	match angle {
 		-1. => Quat::from_rotation_x(FRAC_PI_2),
 		-2. => Quat::from_rotation_x(-FRAC_PI_2),
-		angle => Quat::from_rotation_y((angle - 90.).to_radians()),
+		angle => Quat::from_rotation_y(angle.to_radians() + FRAC_PI_2), // convert from (forward = X) to (forward = -Z)
 	}
 }
 


### PR DESCRIPTION
- 0 0 points to negative Z in Bevy and positive X in TB. So to go from +X to -Z, we need to do a 90 degree rotation counter clockwise. That's +90 degrees, not -90! 
- Fixed the tests that lookeds like accuracy errors by fixing the underlying math
  - BTW, the original inaccuracy you saw was due there being a sneaky sqrt(2) term in there, as you were pointing from the middle of a unit cube to the corner accidentally
- Fixed angle `-1` and `-2` performing no y-rotation to correct the forward vector
- Found out that mangle is not yaw, pitch, roll but actually [yaw, -pitch, roll](https://github.com/TrenchBroom/TrenchBroom/blob/ef515487adf28bb0008408c185520cdc5f45ce29/common/src/mdl/EntityRotation.cpp#L275-L286)

Note that:
- This is not *entirely* correct either, as the [original TrenchBroom code has nontrivial ways of parsing angles](https://github.com/TrenchBroom/TrenchBroom/blob/ef515487adf28bb0008408c185520cdc5f45ce29/common/test/src/mdl/tst_EntityRotation.cpp#L100-L183)
- This fixes #69 iff https://github.com/TrenchBroom/TrenchBroom/pull/4838 is also merged