### PR TITLE
Change `TrenchBroomConfig::generic_material_extensions` default to "toml"

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -130,8 +130,8 @@ pub struct TrenchBroomConfig {
 	///
 	/// Each one of these adds a filesystem call to check if the file exists when loading loose textures, so try to keep this to what you absolutely need.
 	///
-	/// (Default: "material")
-	#[default(["material".s()].into())]
+	/// (Default: "toml" because the default material deserializer is toml)
+	#[default(["toml".s()].into())]
 	#[builder(into)]
 	pub generic_material_extensions: Vec<String>,
 


### PR DESCRIPTION
As the comment says, this is due to the default material deserializer. If we are to have that a default of toml, we might as well have the extension it searches for toml as well.