### PR TITLE
Add global transform* application

### DIFF
--- a/example/avian/main.rs
+++ b/example/avian/main.rs
@@ -16,13 +16,11 @@ pub struct Worldspawn;
 
 #[derive(SolidClass, Component, Reflect)]
 #[reflect(Component)]
-#[base(Transform)]
 #[geometry(GeometryProvider::new().smooth_by_default_angle().convex_collider())]
 pub struct FuncDoor;
 
 #[derive(PointClass, Component, Reflect)]
 #[reflect(Component)]
-#[base(Transform)]
 #[component(on_add = Self::on_add)]
 pub struct Cube;
 impl Cube {

--- a/example/bsp_loading/main.rs
+++ b/example/bsp_loading/main.rs
@@ -22,7 +22,7 @@ pub struct Worldspawn;
 
 #[derive(SolidClass, Component, Reflect, Default)]
 #[reflect(Component)]
-#[base(BspSolidEntity, Transform)]
+#[base(BspSolidEntity)]
 #[geometry(GeometryProvider::new().smooth_by_default_angle().with_lightmaps())]
 pub struct FuncDoor {
 	pub awesome: FgdFlags<FlagsTest>,
@@ -58,7 +58,6 @@ pub struct FuncIllusionary;
 
 #[derive(PointClass, Component, Reflect)]
 #[reflect(Component)]
-#[base(Transform)]
 #[cfg_attr(feature = "example_client", component(on_add = Self::on_add))]
 pub struct Cube;
 #[cfg(feature = "example_client")]
@@ -78,7 +77,6 @@ impl Cube {
 
 #[derive(PointClass, Component, Reflect)]
 #[reflect(Component)]
-#[base(Transform)]
 #[model("models/mushroom.glb")]
 #[size(-4 -4 0, 4 4 16)]
 #[spawn_hook(spawn_class_gltf::<Self>)]

--- a/example/map_loading/main.rs
+++ b/example/map_loading/main.rs
@@ -18,13 +18,11 @@ pub struct Worldspawn;
 
 #[derive(SolidClass, Component, Reflect)]
 #[reflect(Component)]
-#[base(Transform)]
 #[geometry(GeometryProvider::new().smooth_by_default_angle())]
 pub struct FuncDoor;
 
 #[derive(PointClass, Component, Reflect)]
 #[reflect(Component)]
-#[base(Transform)]
 #[cfg_attr(feature = "example_client", component(on_add = Self::on_add))]
 pub struct Cube;
 #[cfg(feature = "example_client")]
@@ -40,7 +38,6 @@ impl Cube {
 
 #[derive(PointClass, Component, Reflect)]
 #[reflect(Component)]
-#[base(Transform)]
 #[model("models/mushroom.glb")]
 #[size(-4 -4 0, 4 4 16)]
 #[spawn_hook(spawn_class_gltf::<Self>)]
@@ -49,7 +46,6 @@ pub struct Mushroom;
 // This is a custom light class for parity with bsp_loading, if you don't support bsps, you should use `PointLight` as base class instead.
 #[derive(PointClass, Component, Reflect, Clone, Copy, SmartDefault)]
 #[reflect(Component)]
-#[base(Transform)]
 #[cfg_attr(feature = "example_client", component(on_add = Self::on_add))]
 pub struct Light {
 	#[default(Color::srgb(1., 1., 1.))]

--- a/readme.md
+++ b/readme.md
@@ -125,7 +125,7 @@ pub struct FuncIllusionary;
 // If your entity has a hardcoded model, you can use a function
 // like `spawn_class_gltf` to do the above automatically.
 #[reflect(Component)]
-#[base(Transform, Visibility)]
+#[base(Visibility)]
 // Sets the in-editor model using TrenchBroom's expression language.
 #[model({ "path": model, "skin": skin })]
 pub struct StaticProp {

--- a/src/bsp/base_classes.rs
+++ b/src/bsp/base_classes.rs
@@ -567,7 +567,6 @@ pub enum BspLightAttenuation {
 /// you can also set a “targetname” key on the “misc_external_map”, or any other keys for “func_door”.
 #[derive(BaseClass, Component, Reflect, Debug, Clone, SmartDefault, Serialize, Deserialize)]
 #[reflect(Component, Default, Serialize, Deserialize)]
-#[base(Transform)]
 #[no_register]
 pub struct BspExternalMap {
 	/// Specifies the filename of the .map to import.

--- a/src/bsp/loader/scene.rs
+++ b/src/bsp/loader/scene.rs
@@ -26,6 +26,7 @@ pub fn initialize_scene(ctx: &mut BspLoadCtx, models: &mut [InternalModel]) -> a
 			.apply_spawn_fn_recursive(&mut QuakeClassSpawnView {
 				config,
 				src_entity: map_entity,
+				class,
 				entity: &mut entity,
 				load_context: ctx.load_context,
 			})
@@ -92,6 +93,7 @@ pub fn initialize_scene(ctx: &mut BspLoadCtx, models: &mut [InternalModel]) -> a
 		(config.global_spawner)(&mut QuakeClassSpawnView {
 			config,
 			src_entity: map_entity,
+			class,
 			entity: &mut entity,
 			load_context: ctx.load_context,
 		})

--- a/src/class/builtin.rs
+++ b/src/class/builtin.rs
@@ -58,9 +58,9 @@ pub fn read_rotation_from_entity(src_entity: &QuakeMapEntity) -> Result<Quat, Qu
 		Err(QuakeEntityError::RequiredPropertyNotFound { .. }) => match src_entity.get::<Vec3>("angles") {
 			Ok(x) => angles_to_quat(x),
 			Err(QuakeEntityError::RequiredPropertyNotFound { .. }) => angle_to_quat(src_entity.get::<f32>("angle").with_default(0.)?),
-			Err(err) => return Err(err.into()),
+			Err(err) => return Err(err),
 		},
-		Err(err) => return Err(err.into()),
+		Err(err) => return Err(err),
 	})
 }
 

--- a/src/class/mod.rs
+++ b/src/class/mod.rs
@@ -141,6 +141,8 @@ impl QuakeClassInfo {
 pub struct QuakeClassSpawnView<'l, 'w, 'sw> {
 	pub config: &'l TrenchBroomConfig,
 	pub src_entity: &'l QuakeMapEntity,
+	/// The class of the entity that is being spawned. Not the class of the [`QuakeClass`] in which this view is passed to (if it is a base class).
+	pub class: &'l ErasedQuakeClass,
 	/// Entity in the scene world.
 	pub entity: &'l mut EntityWorldMut<'sw>,
 	pub load_context: &'l mut LoadContext<'w>,

--- a/src/class/spawn_util.rs
+++ b/src/class/spawn_util.rs
@@ -38,7 +38,6 @@ pub fn spawn_class_model_internal<T: QuakeClass>(view: &mut QuakeClassSpawnView,
 /// # use bevy_trenchbroom::prelude::*;
 /// #[derive(PointClass, Component, Reflect)]
 /// #[reflect(Component)]
-/// #[base(Transform)]
 /// #[model("models/mushroom.glb")]
 /// #[size(-4 -4 0, 4 4 16)]
 /// #[spawn_hook(spawn_class_gltf::<Self>)]
@@ -60,7 +59,6 @@ pub fn spawn_class_gltf<T: QuakeClass>(view: &mut QuakeClassSpawnView) -> anyhow
 /// # use bevy_trenchbroom::prelude::*;
 /// #[derive(PointClass, Component, Reflect)]
 /// #[reflect(Component)]
-/// #[base(Transform)]
 /// #[model("models/torch.glb")]
 /// #[spawn_hook(preload_model::<Self>)]
 /// pub struct Torch;
@@ -101,7 +99,6 @@ fn preloading() {
 	#[derive(PointClass, Component, Reflect)]
 	#[reflect(Component)]
 	#[no_register]
-	#[base(Transform)]
 	#[model("models/mushroom.glb")]
 	#[spawn_hook(preload_model::<Self>)]
 	#[component(on_add = Self::on_add)]

--- a/src/config/main_impl.rs
+++ b/src/config/main_impl.rs
@@ -1,4 +1,4 @@
-use crate::util::AssetServerExistsExt;
+use crate::{class::builtin::{read_rotation_from_entity, read_translation_from_entity}, util::AssetServerExistsExt};
 
 use super::*;
 
@@ -47,6 +47,14 @@ impl TrenchBroomConfig {
 	pub fn default_global_spawner(view: &mut QuakeClassSpawnView) -> anyhow::Result<()> {
 		let classname = view.src_entity.classname()?.s();
 
+		if view.config.global_transform_application && !view.class.info.derives_from::<Transform>() {
+			view.entity.insert(Transform {
+				translation: read_translation_from_entity(view.src_entity, view.config)?,
+				rotation: read_rotation_from_entity(view.src_entity)?,
+				scale: Vec3::ONE,
+			});
+		}
+		
 		// For things like doors where the `angles` property means open direction.
 		if let Some(mut transform) = view.entity.get_mut::<Transform>() {
 			if view.config.get_class(&classname).map(|class| class.info.ty.is_solid()) == Some(true) {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -243,6 +243,15 @@ pub struct TrenchBroomConfig {
 	#[default(Hook(Arc::new(Self::default_global_geometry_provider)))]
 	pub global_geometry_provider: Hook<GeometryProviderFn>,
 
+	/// Whether to apply the translation and rotation fields regardless of having [`Transform`] as a base class.
+	/// Adds convenance and removes a foot-gun, but is less flexible, hence why it is disableable.
+	///
+	/// NOTE: This doesn't use the scale field as it is not hardcoded unlike the others. If you want to use it, then you should use [`Transform`] as a base class.
+	///
+	/// (Default: `true`)
+	#[default(true)]
+	pub global_transform_application: bool,
+
 	/// The image sampler used with textures loaded from maps.
 	/// Use [`Self::linear_filtering`] to easily switch to smooth texture interpolation.
 	/// (Default: [`Self::default_texture_sampler`] (repeating nearest neighbor))

--- a/src/qmap/loader.rs
+++ b/src/qmap/loader.rs
@@ -91,6 +91,7 @@ impl AssetLoader for QuakeMapLoader {
 					.apply_spawn_fn_recursive(&mut QuakeClassSpawnView {
 						config: &self.tb_server.config,
 						src_entity: map_entity,
+						class,
 						entity: &mut entity,
 						load_context,
 					})
@@ -226,6 +227,7 @@ impl AssetLoader for QuakeMapLoader {
 				(self.tb_server.config.global_spawner)(&mut QuakeClassSpawnView {
 					config: &self.tb_server.config,
 					src_entity: map_entity,
+					class,
 					entity: &mut entity,
 					load_context,
 				})


### PR DESCRIPTION
Adds convenience and removes a potential foot gun, especially with the removal of `#[require(...)]` adding base classes. This has the cost of a little logic fragmenting.

The main reason i'm good with this is because position and rotation properties are also hardcoded on every entity in TrenchBroom if you use their associated tools, meaning this change makes the crate align more with what's seen in-editor by default.
*The exception to this is `scale`, which isn't hardcoded at all, completely user-defined, which is why scale isn't currently applied with the global applicator. If we make a scale property a more structured thing in the config in the future, this could very well change.