### PR TITLE
Move `QuakeClass` registration to the type registry, removing the `auto_register` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,7 +1559,6 @@ dependencies = [
  "enumflags2",
  "float-ord",
  "image",
- "inventory",
  "itertools 0.14.0",
  "json",
  "ndshape",
@@ -3174,15 +3173,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "inventory"
-version = "0.3.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab08d7cd2c5897f2c949e5383ea7c7db03fb19130ffcfbf7eda795137ae3cb83"
-dependencies = [
- "rustversion",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,6 @@ disjoint-sets = "0.4.2"
 qbsp = { git = "https://github.com/Noxmore/qbsp.git", rev = "cc0b9e3", features = ["bevy_reflect", "serde"] }
 nil.workspace = true
 ndshape = "0.3.0"
-inventory = { version = "0.3", optional = true }
 strum = { version = "0.27", features = ["derive"] }
 enumflags2.workspace = true
 serde_json = "1.0.140"
@@ -79,11 +78,10 @@ bevy = { version = "0.16", default-features = false, features = [
 smol = "2"
 
 [features]
-default = ["client", "auto_register"]
+default = ["client"]
 client = ["bevy/bevy_pbr", "bevy_materialize/bevy_pbr"]
 rapier = ["dep:bevy_rapier3d"]
 avian = ["dep:avian3d"]
-auto_register = ["dep:inventory", "bevy_trenchbroom_macros/auto_register"]
 
 [patch.crates-io]
 avian3d = { git = "https://github.com/Jondolf/avian.git", branch = "main" }

--- a/example/avian/main.rs
+++ b/example/avian/main.rs
@@ -1,37 +1,19 @@
 use avian3d::prelude::*;
-use bevy::ecs::component::HookContext;
-use bevy::ecs::world::DeferredWorld;
 use bevy::math::*;
 use bevy::prelude::*;
 use bevy_flycam::prelude::*;
 use bevy_trenchbroom::prelude::*;
 use nil::prelude::*;
 
-// TODO: We aren't using inventory to register here because it's broken on wasm. The `auto_register` feature is turned off.
-
 #[derive(SolidClass, Component, Reflect)]
-#[reflect(Component)]
+#[reflect(QuakeClass, Component)]
 #[geometry(GeometryProvider::new().smooth_by_default_angle().convex_collider())]
 pub struct Worldspawn;
 
 #[derive(SolidClass, Component, Reflect)]
-#[reflect(Component)]
+#[reflect(QuakeClass, Component)]
 #[geometry(GeometryProvider::new().smooth_by_default_angle().convex_collider())]
 pub struct FuncDoor;
-
-#[derive(PointClass, Component, Reflect)]
-#[reflect(Component)]
-#[component(on_add = Self::on_add)]
-pub struct Cube;
-impl Cube {
-	fn on_add(mut world: DeferredWorld, ctx: HookContext) {
-		let Some(asset_server) = world.get_resource::<AssetServer>() else { return };
-		let cube = asset_server.add(Mesh::from(Cuboid::new(0.42, 0.42, 0.42)));
-		let material = asset_server.add(StandardMaterial::default());
-
-		world.commands().entity(ctx.entity).insert((Mesh3d(cube), MeshMaterial3d(material)));
-	}
-}
 
 fn main() {
 	App::new()
@@ -52,12 +34,10 @@ fn main() {
 		.add_plugins(bevy_inspector_egui::quick::WorldInspectorPlugin::default())
 		.add_systems(Update, make_unlit)
 		.add_plugins(TrenchBroomPlugin(
-			TrenchBroomConfig::new("bevy_trenchbroom_example")
-				.no_bsp_lighting(true)
-				.register_class::<Worldspawn>()
-				.register_class::<Cube>()
-				.register_class::<FuncDoor>(),
+			TrenchBroomConfig::new("bevy_trenchbroom_example").no_bsp_lighting(true),
 		))
+		.register_type::<Worldspawn>()
+		.register_type::<FuncDoor>()
 		.add_systems(PostStartup, setup_scene)
 		.add_systems(FixedUpdate, spawn_cubes)
 		.run();

--- a/example/bsp_loading/main.rs
+++ b/example/bsp_loading/main.rs
@@ -12,16 +12,14 @@ use bevy_trenchbroom::prelude::*;
 use enumflags2::*;
 use nil::prelude::*;
 
-// TODO: We aren't using inventory to register here because it's broken on wasm. The `auto_register` feature is turned off.
-
 #[derive(SolidClass, Component, Reflect)]
-#[reflect(Component)]
+#[reflect(QuakeClass, Component)]
 #[base(BspWorldspawn)]
 #[geometry(GeometryProvider::new().smooth_by_default_angle().with_lightmaps())]
 pub struct Worldspawn;
 
 #[derive(SolidClass, Component, Reflect, Default)]
-#[reflect(Component)]
+#[reflect(QuakeClass, Component)]
 #[base(BspSolidEntity)]
 #[geometry(GeometryProvider::new().smooth_by_default_angle().with_lightmaps())]
 pub struct FuncDoor {
@@ -39,25 +37,25 @@ pub enum FlagsTest {
 }
 
 #[derive(SolidClass, Component, Reflect)]
-#[reflect(Component)]
+#[reflect(QuakeClass, Component)]
 #[base(BspSolidEntity)]
 #[geometry(GeometryProvider::new().smooth_by_default_angle().with_lightmaps())]
 pub struct FuncWall;
 
 #[derive(SolidClass, Component, Reflect)]
-#[reflect(Component)]
+#[reflect(QuakeClass, Component)]
 #[base(BspSolidEntity)]
 #[geometry(GeometryProvider::new())] // Compiler-handled
 pub struct FuncDetail;
 
 #[derive(SolidClass, Component, Reflect)]
-#[reflect(Component)]
+#[reflect(QuakeClass, Component)]
 #[base(BspSolidEntity)]
 #[geometry(GeometryProvider::new().smooth_by_default_angle().with_lightmaps())]
 pub struct FuncIllusionary;
 
 #[derive(PointClass, Component, Reflect)]
-#[reflect(Component)]
+#[reflect(QuakeClass, Component)]
 #[cfg_attr(feature = "example_client", component(on_add = Self::on_add))]
 pub struct Cube;
 #[cfg(feature = "example_client")]
@@ -76,14 +74,14 @@ impl Cube {
 }
 
 #[derive(PointClass, Component, Reflect)]
-#[reflect(Component)]
+#[reflect(QuakeClass, Component)]
 #[model("models/mushroom.glb")]
 #[size(-4 -4 0, 4 4 16)]
 #[spawn_hook(spawn_class_gltf::<Self>)]
 pub struct Mushroom;
 
 #[derive(PointClass, Component, Reflect, SmartDefault)]
-#[reflect(Component)]
+#[reflect(QuakeClass, Component)]
 #[base(BspLight, Transform)]
 // This is the default size, this is just to make sure it produces a valid fgd.
 #[size(-8 -8 -8, 8 8 8)]
@@ -121,14 +119,14 @@ fn main() {
 			TrenchBroomConfig::new("bevy_trenchbroom_example")
 				.suppress_invalid_entity_definitions(true)
 				.bicubic_lightmap_filtering(true)
-				.compute_lightmap_settings(ComputeLightmapSettings { extrusion: 1, ..default() })
-				.register_class::<Worldspawn>()
-				.register_class::<Cube>()
-				.register_class::<Mushroom>()
-				.register_class::<FuncWall>()
-				.register_class::<Light>()
-				.register_class::<FuncDoor>(),
+				.compute_lightmap_settings(ComputeLightmapSettings { extrusion: 1, ..default() }),
 		))
+		.register_type::<Worldspawn>()
+		.register_type::<Cube>()
+		.register_type::<Mushroom>()
+		.register_type::<FuncWall>()
+		.register_type::<Light>()
+		.register_type::<FuncDoor>()
 		.add_systems(PostStartup, (setup_scene, write_config))
 		.run();
 }
@@ -168,10 +166,10 @@ fn setup_scene(
 	}
 }
 
-fn write_config(#[allow(unused)] server: Res<TrenchBroomServer>) {
+fn write_config(#[allow(unused)] server: Res<TrenchBroomServer>, type_registry: Res<AppTypeRegistry>) {
 	#[cfg(not(target_family = "wasm"))]
 	{
-		server.config.write_game_config_to_default_directory().unwrap();
+		server.config.write_game_config_to_default_directory(&type_registry.read()).unwrap();
 		server.config.add_game_to_preferences_in_default_directory().unwrap();
 	}
 }

--- a/example/map_loading/main.rs
+++ b/example/map_loading/main.rs
@@ -9,20 +9,18 @@ use bevy_flycam::prelude::*;
 use bevy_trenchbroom::prelude::*;
 use nil::prelude::*;
 
-// TODO: We aren't using inventory to register here because it's broken on wasm. The `auto_register` feature is turned off.
-
 #[derive(SolidClass, Component, Reflect)]
-#[reflect(Component)]
+#[reflect(QuakeClass, Component)]
 #[geometry(GeometryProvider::new().smooth_by_default_angle())]
 pub struct Worldspawn;
 
 #[derive(SolidClass, Component, Reflect)]
-#[reflect(Component)]
+#[reflect(QuakeClass, Component)]
 #[geometry(GeometryProvider::new().smooth_by_default_angle())]
 pub struct FuncDoor;
 
 #[derive(PointClass, Component, Reflect)]
-#[reflect(Component)]
+#[reflect(QuakeClass, Component)]
 #[cfg_attr(feature = "example_client", component(on_add = Self::on_add))]
 pub struct Cube;
 #[cfg(feature = "example_client")]
@@ -37,7 +35,7 @@ impl Cube {
 }
 
 #[derive(PointClass, Component, Reflect)]
-#[reflect(Component)]
+#[reflect(QuakeClass, Component)]
 #[model("models/mushroom.glb")]
 #[size(-4 -4 0, 4 4 16)]
 #[spawn_hook(spawn_class_gltf::<Self>)]
@@ -45,7 +43,7 @@ pub struct Mushroom;
 
 // This is a custom light class for parity with bsp_loading, if you don't support bsps, you should use `PointLight` as base class instead.
 #[derive(PointClass, Component, Reflect, Clone, Copy, SmartDefault)]
-#[reflect(Component)]
+#[reflect(QuakeClass, Component)]
 #[cfg_attr(feature = "example_client", component(on_add = Self::on_add))]
 pub struct Light {
 	#[default(Color::srgb(1., 1., 1.))]
@@ -98,14 +96,13 @@ fn main() {
 			ClientPlugin,
 		))
 		.add_plugins(TrenchBroomPlugin(
-			TrenchBroomConfig::new("bevy_trenchbroom_example")
-				.no_bsp_lighting(true)
-				.register_class::<Worldspawn>()
-				.register_class::<Cube>()
-				.register_class::<Mushroom>()
-				.register_class::<Light>()
-				.register_class::<FuncDoor>(),
+			TrenchBroomConfig::new("bevy_trenchbroom_example").no_bsp_lighting(true),
 		))
+		.register_type::<Worldspawn>()
+		.register_type::<Cube>()
+		.register_type::<Mushroom>()
+		.register_type::<Light>()
+		.register_type::<FuncDoor>()
 		.add_systems(PostStartup, setup_scene)
 		.run();
 }

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -16,6 +16,3 @@ heck = "0.5"
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "2", features = [ "extra-traits", "parsing", "printing" ] }
-
-[features]
-auto_register = []

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -8,8 +8,6 @@ use syn::*;
 
 /// Point classes don't have any geometry built in -- simply a point in space.
 ///
-/// If the `auto_register` feature is enabled, this will automatically register the type with `bevy_trenchbroom`.
-///
 /// # Type attributes
 /// - `#[model(<path expression>)]` Displays the entity as the specified model in-editor.
 /// - `#[model({ "path": <path expr>, "skin": <skin expr>, "frame": <frame expr>, "scale": <scale expr> })]` Same as above attribute, but with greater control over how the model is shown. Note that any of these properties can be left out.
@@ -20,45 +18,33 @@ use syn::*;
 /// - `#[classname(<string>)]` When outputted to fgd, use the specified string instead of a classname with case converted via the previous attribute.
 /// - `#[base(<type ...>)]` Adds base classes to inherit.
 /// - `#[spawn_hook(<QuakeClassSpawnFn expression>)]` A custom function to run inside the spawn function of this class. Use for things like spawning models.
-/// - `#[no_register]` Doesn't automatically register even if the `auto_register` feature is enabled.
 ///
 /// # Field attributes
 /// - `#[no_default]` Use on fields you want to output an error if not defined, rather than just being replaced by the field's default value.
-#[proc_macro_derive(
-	PointClass,
-	attributes(model, color, iconsprite, size, classname, base, spawn_hook, no_register, no_default)
-)]
+#[proc_macro_derive(PointClass, attributes(model, color, iconsprite, size, classname, base, spawn_hook, no_default))]
 pub fn point_class_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 	quake_class::class_derive(parse_macro_input!(input as DeriveInput), quake_class::QuakeClassType::Point).into()
 }
 
 /// Solid classes contain brush geometry.
 ///
-/// If the `auto_register` feature is enabled, this will automatically register the type with `bevy_trenchbroom`.
-///
 /// # Type attributes
 /// - `#[geometry(<rust expression>)]` Required. An expression that produces a `GeometryProvider` to control how the geometry appears in the world.
 /// - `#[classname(<case type>)]` Case type can be something like `PascalCase` or `snake_case`. Default if not specified is `snake_case`.
 /// - `#[classname(<string>)]` When outputted to fgd, use the specified string instead of a classname with case converted via the previous attribute.
 /// - `#[base(<type ...>)]` Adds base classes to inherit.
-/// - `#[no_register]` Doesn't automatically register even if the `auto_register` feature is enabled.
 ///
 /// # Field attributes
 /// - `#[no_default]` Use on fields you want to output an error if not defined, rather than just being replaced by the field's default value.
-#[proc_macro_derive(SolidClass, attributes(geometry, classname, base, no_register, no_default))]
+#[proc_macro_derive(SolidClass, attributes(geometry, classname, base, no_default))]
 pub fn solid_class_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 	quake_class::class_derive(parse_macro_input!(input as DeriveInput), quake_class::QuakeClassType::Solid).into()
 }
 
 /// Base classes don't appear in-editor, rather they give properties and attributes to their sub-classes (components that require them).
 ///
-/// If the `auto_register` feature is enabled, this will automatically register the type with `bevy_trenchbroom`.
-///
 /// It has the same attributes as [`PointClass`].
-#[proc_macro_derive(
-	BaseClass,
-	attributes(model, color, iconsprite, size, classname, base, spawn_hook, no_register, no_default)
-)]
+#[proc_macro_derive(BaseClass, attributes(model, color, iconsprite, size, classname, base, spawn_hook, no_default))]
 pub fn base_class_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 	quake_class::class_derive(parse_macro_input!(input as DeriveInput), quake_class::QuakeClassType::Base).into()
 }

--- a/macros/src/quake_class.rs
+++ b/macros/src/quake_class.rs
@@ -173,12 +173,6 @@ pub(super) fn class_derive(input: DeriveInput, ty: QuakeClassType) -> TokenStrea
 		panic!("Solid classes must have a `#[geometry(...)]` attribute.");
 	}
 
-	let inventory_submit = (cfg!(feature = "auto_register") && !opts.no_register).then(|| {
-		quote! {
-			::bevy_trenchbroom::inventory::submit! { <#ident as ::bevy_trenchbroom::class::QuakeClass>::ERASED_CLASS }
-		}
-	});
-
 	let name = opts
 		.classname
 		.and_then(|tokens| tokens.into_iter().next())
@@ -240,7 +234,5 @@ pub(super) fn class_derive(input: DeriveInput, ty: QuakeClassType) -> TokenStrea
 				Ok(())
 			}
 		}
-
-		#inventory_submit
 	}
 }

--- a/macros/src/quake_class.rs
+++ b/macros/src/quake_class.rs
@@ -20,7 +20,6 @@ struct Opts {
 	base: Vec<Type>,
 	spawn_hook: Option<Expr>,
 
-	no_register: bool,
 	doc: Option<String>,
 }
 
@@ -79,11 +78,7 @@ pub(super) fn class_derive(input: DeriveInput, ty: QuakeClassType) -> TokenStrea
 					opts.spawn_hook = Some(Expr::parse.parse2(meta.tokens).expect("`spawn_hook` attribute not an expression"));
 				}
 			}
-			Meta::Path(path) => {
-				if compare_path(&path, "no_register") {
-					opts.no_register = true;
-				}
-			}
+			_ => {}
 		}
 	}
 

--- a/readme.md
+++ b/readme.md
@@ -283,7 +283,7 @@ First, enable the `rapier` or `avian` feature on the crate, then either call `co
 
 For dedicated servers `bevy_trenchbroom` supports headless mode by turning off its `client` feature. e.g.
 ```toml
-bevy_trenchbroom = { version = "...", default-features = false, features = ["auto_register"] }
+bevy_trenchbroom = { version = "...", default-features = false }
 ```
 
 # Possible future plans

--- a/readme.md
+++ b/readme.md
@@ -61,7 +61,7 @@ use bevy_trenchbroom::bsp::base_classes::*;
 // The required worldspawn class makes up the main structural
 // world geometry and settings. Exactly one exists in every map.
 #[derive(SolidClass, Component, Reflect, Default)]
-#[reflect(Component)]
+#[reflect(QuakeClass, Component)]
 // Quake classes use an inheritance system alike OOP
 // programming languages.
 // If you're using a BSP workflow, this base class includes a bunch
@@ -78,7 +78,7 @@ pub struct Worldspawn {
 // those which use it as a base class
 // by using the `base` attribute.
 #[derive(BaseClass, Component, Reflect, Default)]
-#[reflect(Component)]
+#[reflect(QuakeClass, Component)]
 pub struct MyBaseClass {
     /// Documentation comments will be visible in-editor!
     pub my_value: u32,
@@ -87,7 +87,7 @@ pub struct MyBaseClass {
 // SolidClass (also known as brush entities) makes the class
 // contain its own geometry, such as a door or breakable
 #[derive(SolidClass, Component, Reflect)]
-#[reflect(Component)]
+#[reflect(QuakeClass, Component)]
 #[base(Visibility, MyBaseClass)]
 #[geometry(GeometryProvider::new().trimesh_collider().smooth_by_default_angle().with_lightmaps())]
 // By default, names are converted into snake_case.
@@ -99,7 +99,7 @@ pub struct MyBaseClass {
 pub struct FuncWall;
 
 #[derive(SolidClass, Component, Reflect)]
-#[reflect(Component)]
+#[reflect(QuakeClass, Component)]
 // If you're using a BSP workflow, this base class includes a bunch
 // of useful compiler properties.
 #[base(BspSolidEntity)]
@@ -124,7 +124,7 @@ pub struct FuncIllusionary;
 //
 // If your entity has a hardcoded model, you can use a function
 // like `spawn_class_gltf` to do the above automatically.
-#[reflect(Component)]
+#[reflect(QuakeClass, Component)]
 #[base(Visibility)]
 // Sets the in-editor model using TrenchBroom's expression language.
 #[model({ "path": model, "skin": skin })]
@@ -156,7 +156,7 @@ impl Default for StaticProp {
 #[derive(PointClass, Component, Reflect)]
 // Here you'd use #[spawn_hook(<function>)], a component hook, or a system to
 // add a RigidBody of your preferred physics engine.
-#[reflect(Component)]
+#[reflect(QuakeClass, Component)]
 #[base(StaticProp)]
 pub struct PhysicsProp;
 
@@ -173,12 +173,9 @@ pub enum CollisionType {
 }
 ```
 
-If the `auto_register` feature is enabled (default), just defining these classes will automatically register them with all `TrenchBroomConfig`s.
-Otherwise, you'll have to call `TrenchBroomConfig::register_class<Class>()` to register each one.
+Now, just register these like you would any other type via `App::register_type::<T>()`, and you are good to go!
 
-The types themselves will also need to be registered with Bevy, but if `TrenchBroomConfig::register_entity_class_types` is enabled (default), that will also happen automatically.
-
-Now to access the config from TrenchBroom, at some point in your application, you need to call `TrenchBroomConfig::write_game_config` and `TrenchBroomConfig::add_game_to_preferences`. For example:
+To access the config from TrenchBroom, at some point in your application, you need to call `TrenchBroomConfig::write_game_config` and `TrenchBroomConfig::add_game_to_preferences`. For example:
 
 ```rust
 use bevy::prelude::*;
@@ -186,10 +183,13 @@ use bevy_trenchbroom::prelude::*;
 
 // app.add_systems(Startup, write_trenchbroom_config)
 
-fn write_trenchbroom_config(server: Res<TrenchBroomServer>) {
+fn write_trenchbroom_config(
+    server: Res<TrenchBroomServer>,
+    type_registry: Res<AppTypeRegistry>,
+) {
     // This will write <TB folder>/games/example_game/GameConfig.cfg,
     // and <TB folder>/games/example_game/example_game.fgd
-    if let Err(err) = server.config.write_game_config_to_default_directory() {
+    if let Err(err) = server.config.write_game_config_to_default_directory(&type_registry.read()) {
         error!("Could not write TrenchBroom game config: {err}");
     }
 

--- a/src/bsp/base_classes.rs
+++ b/src/bsp/base_classes.rs
@@ -18,8 +18,7 @@ impl Plugin for BspBaseClassesPlugin {
 
 /// Contains properties used by the `ericw-tools` compiler for any entity with a brush model.
 #[derive(BaseClass, Component, Reflect, Debug, Clone, SmartDefault, Serialize, Deserialize)]
-#[reflect(Component, Default, Serialize, Deserialize)]
-#[no_register]
+#[reflect(QuakeClass, Component, Default, Serialize, Deserialize)]
 pub struct BspSolidEntity {
 	/// Generates an `LMSHIFT` BSPX lump for use by a light util. Note that both scaled and unscaled lighting will normally be used.
 	pub _lmscale: Option<u32>,
@@ -195,9 +194,8 @@ pub struct BspSolidEntity {
 
 /// Contains properties used by the `ericw-tools` compiler for the `worldspawn` entity.
 #[derive(BaseClass, Component, Reflect, Debug, Clone, SmartDefault, Serialize, Deserialize)]
-#[reflect(Component, Default, Serialize, Deserialize)]
+#[reflect(QuakeClass, Component, Default, Serialize, Deserialize)]
 #[base(BspSolidEntity)]
-#[no_register]
 pub struct BspWorldspawn {
 	/// (Not documented, but hopefully self-explanatory.)
 	pub _maxlight: Option<f32>,
@@ -359,8 +357,7 @@ pub enum DirtMode {
 
 /// Contains properties used by the `ericw-tools` compiler for any entity with a classname starting with the first five letters "light". E.g. "light", "light_globe", "light_flame_small_yellow", etc.
 #[derive(BaseClass, Component, Reflect, Debug, Clone, SmartDefault, Serialize, Deserialize)]
-#[reflect(Component, Default, Serialize, Deserialize)]
-#[no_register]
+#[reflect(QuakeClass, Component, Default, Serialize, Deserialize)]
 pub struct BspLight {
 	/// Set the light intensity. Negative values are also allowed and will cause the entity to subtract light cast by other entities. Default 300.
 	#[default(300.)]
@@ -566,8 +563,7 @@ pub enum BspLightAttenuation {
 /// e.g. if you set “_external_map_classname” to “func_door”,
 /// you can also set a “targetname” key on the “misc_external_map”, or any other keys for “func_door”.
 #[derive(BaseClass, Component, Reflect, Debug, Clone, SmartDefault, Serialize, Deserialize)]
-#[reflect(Component, Default, Serialize, Deserialize)]
-#[no_register]
+#[reflect(QuakeClass, Component, Default, Serialize, Deserialize)]
 pub struct BspExternalMap {
 	/// Specifies the filename of the .map to import.
 	#[no_default]

--- a/src/bsp/loader/mod.rs
+++ b/src/bsp/loader/mod.rs
@@ -28,6 +28,7 @@ pub(crate) struct BspLoadCtx<'a, 'lc: 'a> {
 	pub loader: &'a BspLoader,
 	pub load_context: &'a mut LoadContext<'lc>,
 	pub asset_server: &'a AssetServer,
+	pub type_registry: &'a AppTypeRegistry,
 	pub data: &'a BspData,
 	pub entities: &'a QuakeMapEntities,
 }
@@ -35,12 +36,14 @@ pub(crate) struct BspLoadCtx<'a, 'lc: 'a> {
 pub struct BspLoader {
 	pub tb_server: TrenchBroomServer,
 	pub asset_server: AssetServer,
+	pub type_registry: AppTypeRegistry,
 }
 impl FromWorld for BspLoader {
 	fn from_world(world: &mut World) -> Self {
 		Self {
 			tb_server: world.resource::<TrenchBroomServer>().clone(),
 			asset_server: world.resource::<AssetServer>().clone(),
+			type_registry: world.resource::<AppTypeRegistry>().clone(),
 		}
 	}
 }
@@ -76,6 +79,7 @@ impl AssetLoader for BspLoader {
 				loader: self,
 				load_context,
 				asset_server: &self.asset_server,
+				type_registry: &self.type_registry,
 				data: &data,
 				entities: &entities,
 			};

--- a/src/class/builtin.rs
+++ b/src/class/builtin.rs
@@ -1,6 +1,5 @@
 //! Builtin [`QuakeClass`] implementations.
 
-use bsp::base_classes::*;
 use fgd::FgdType;
 use qmap::{QuakeEntityError, QuakeEntityErrorResultExt};
 use util::{angle_to_quat, angles_to_quat, mangle_to_quat};
@@ -8,33 +7,25 @@ use util::{angle_to_quat, angles_to_quat, mangle_to_quat};
 use super::*;
 use crate::*;
 
-/// Returns the default registry used in [`TrenchBroomConfig`], containing a bunch of useful foundational and utility classes to greatly reduce boilerplate.
-pub fn default_quake_class_registry() -> HashMap<&'static str, Cow<'static, ErasedQuakeClass>> {
-	macro_rules! registry {
-		{$($(#[$($attrs:meta)*])? $ty:ident),* $(,)?} => {
-			[
-				$(
-					$(#[$($attrs)*])?
-					($ty::CLASS_INFO.name, Cow::Borrowed($ty::ERASED_CLASS)
-				)),*
-			].into_iter().collect()
-		};
-	}
+pub struct BuiltinClassesPlugin;
+impl Plugin for BuiltinClassesPlugin {
+	fn build(&self, app: &mut App) {
+		#[rustfmt::skip]
+		app
+			.register_type_data::<Transform, ReflectQuakeClass>()
 
-	registry! {
-		Transform,
-		#[cfg(feature = "client")] Visibility,
-		#[cfg(feature = "client")] PointLight,
-		#[cfg(feature = "client")] SpotLight,
-		#[cfg(feature = "client")] DirectionalLight,
+			.register_type::<Target>()
+			.register_type::<Targetable>()
+		;
 
-		Target,
-		Targetable,
-
-		BspSolidEntity,
-		BspWorldspawn,
-		BspLight,
-		BspExternalMap,
+		#[cfg(feature = "client")]
+		#[rustfmt::skip]
+		app
+			.register_type_data::<Visibility, ReflectQuakeClass>()
+			.register_type_data::<PointLight, ReflectQuakeClass>()
+			.register_type_data::<SpotLight, ReflectQuakeClass>()
+			.register_type_data::<DirectionalLight, ReflectQuakeClass>()
+		;
 	}
 }
 
@@ -473,8 +464,7 @@ impl QuakeClass for DirectionalLight {
 ///
 /// TODO: this is currently just a skeleton struct, first-class entity IO hasn't been added yet.
 #[derive(BaseClass, Component, Reflect, Debug, Clone, SmartDefault, Serialize, Deserialize)]
-#[reflect(Component, Default, Serialize, Deserialize)]
-#[no_register]
+#[reflect(QuakeClass, Component, Default, Serialize, Deserialize)]
 pub struct Target {
 	/// If [`Some`], when this entity's IO fires, it will activate all entities with its [`Targetable::targetname`] set to this, with whatever input that functionality that entity has set up.
 	pub target: Option<String>,
@@ -486,8 +476,7 @@ pub struct Target {
 ///
 /// TODO: this is currently just a skeleton struct, first-class entity IO hasn't been added yet.
 #[derive(BaseClass, Component, Reflect, Debug, Clone, SmartDefault, Serialize, Deserialize)]
-#[reflect(Component, Default, Serialize, Deserialize)]
-#[no_register]
+#[reflect(QuakeClass, Component, Default, Serialize, Deserialize)]
 pub struct Targetable {
 	/// The name for entities with [`Target`] components to point to.
 	pub targetname: Option<String>,

--- a/src/class/mod.rs
+++ b/src/class/mod.rs
@@ -114,7 +114,7 @@ impl QuakeClassInfo {
 	/// # use bevy::prelude::*;
 	/// # use bevy_trenchbroom::prelude::*;
 	/// #[derive(PointClass, Reflect, Component)]
-	/// #[reflect(Component)]
+	/// #[reflect(QuakeClass, Component)]
 	/// #[model("models/my_class.glb")]
 	/// struct MyClass;
 	///

--- a/src/class/mod.rs
+++ b/src/class/mod.rs
@@ -2,7 +2,7 @@ pub mod builtin;
 pub mod spawn_util;
 
 use bevy::{asset::LoadContext, platform::collections::HashSet};
-use bevy_reflect::{FromType, GetTypeRegistration, TypeRegistration, TypeRegistry};
+use bevy_reflect::{FromType, TypeRegistry};
 use geometry::GeometryProvider;
 use qmap::QuakeMapEntity;
 
@@ -157,7 +157,7 @@ impl QuakeClassSpawnView<'_, '_, '_> {
 	}
 }
 
-pub trait QuakeClass: Component + GetTypeRegistration + Sized {
+pub trait QuakeClass: Component + Reflect + Sized {
 	/// A global [`ErasedQuakeClass`] of this type. Used for base classes and registration.
 	///
 	/// Everything i've read seems a little vague on this situation, but in testing it seems like this acts like a static.
@@ -177,8 +177,6 @@ pub struct ErasedQuakeClass {
 	pub type_id: fn() -> TypeId,
 	pub info: QuakeClassInfo,
 	pub spawn_fn: QuakeClassSpawnFn,
-	pub get_type_registration: fn() -> TypeRegistration,
-	pub register_type_dependencies: fn(&mut TypeRegistry),
 }
 impl ErasedQuakeClass {
 	pub const fn of<T: QuakeClass>() -> Self {
@@ -186,8 +184,6 @@ impl ErasedQuakeClass {
 			type_id: TypeId::of::<T>,
 			info: T::CLASS_INFO,
 			spawn_fn: T::class_spawn,
-			get_type_registration: T::get_type_registration,
-			register_type_dependencies: T::register_type_dependencies,
 		}
 	}
 

--- a/src/class/spawn_util.rs
+++ b/src/class/spawn_util.rs
@@ -97,8 +97,7 @@ fn preloading() {
 	use bevy::render::view::VisibilityClass;
 
 	#[derive(PointClass, Component, Reflect)]
-	#[reflect(Component)]
-	#[no_register]
+	#[reflect(QuakeClass, Component)]
 	#[model("models/mushroom.glb")]
 	#[spawn_hook(preload_model::<Self>)]
 	#[component(on_add = Self::on_add)]
@@ -127,9 +126,7 @@ fn preloading() {
 			ImagePlugin::default(),
 		))
 		.insert_resource(TrenchBroomServer::new(
-			TrenchBroomConfig::default()
-				.suppress_invalid_entity_definitions(true)
-				.register_class::<Mushroom>(),
+			TrenchBroomConfig::default().suppress_invalid_entity_definitions(true),
 		))
 		.register_type::<Mushroom>()
 		.register_type::<bevy::pbr::LightProbe>()

--- a/src/class/spawn_util.rs
+++ b/src/class/spawn_util.rs
@@ -37,7 +37,7 @@ pub fn spawn_class_model_internal<T: QuakeClass>(view: &mut QuakeClassSpawnView,
 /// # use bevy::prelude::*;
 /// # use bevy_trenchbroom::prelude::*;
 /// #[derive(PointClass, Component, Reflect)]
-/// #[reflect(Component)]
+/// #[reflect(QuakeClass, Component)]
 /// #[model("models/mushroom.glb")]
 /// #[size(-4 -4 0, 4 4 16)]
 /// #[spawn_hook(spawn_class_gltf::<Self>)]
@@ -58,7 +58,7 @@ pub fn spawn_class_gltf<T: QuakeClass>(view: &mut QuakeClassSpawnView) -> anyhow
 /// # use bevy::prelude::*;
 /// # use bevy_trenchbroom::prelude::*;
 /// #[derive(PointClass, Component, Reflect)]
-/// #[reflect(Component)]
+/// #[reflect(QuakeClass, Component)]
 /// #[model("models/torch.glb")]
 /// #[spawn_hook(preload_model::<Self>)]
 /// pub struct Torch;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -12,7 +12,6 @@ use bevy::{
 	tasks::BoxedFuture,
 };
 use bsp::GENERIC_MATERIAL_PREFIX;
-use class::{ErasedQuakeClass, QuakeClass, builtin::default_quake_class_registry};
 use fgd::FgdType;
 use geometry::{GeometryProviderFn, GeometryProviderView};
 use qmap::QuakeMapEntities;
@@ -223,15 +222,6 @@ pub struct TrenchBroomConfig {
 
 	/// `qbsp` settings when parsing BSP files.
 	pub bsp_parse_settings: BspParseSettings,
-
-	/// Whether to automatically register the types stored in [`Self::entity_classes`], reducing boilerplate. (Default: true)
-	#[default(true)]
-	pub register_entity_class_types: bool,
-
-	/// Registered entity classes to be outputted in the fgd file, and used when spawning into scenes. (Default: [`default_quake_class_registry`])
-	#[default(default_quake_class_registry())]
-	#[builder(skip)]
-	pub entity_classes: HashMap<&'static str, Cow<'static, ErasedQuakeClass>>,
 
 	/// Entity spawners that get run on every single entity (after the regular spawners), regardless of classname. (Default: [`TrenchBroomConfig::default_global_spawner`])
 	#[builder(skip)]

--- a/src/config/writing.rs
+++ b/src/config/writing.rs
@@ -1,3 +1,7 @@
+use bevy_reflect::TypeRegistry;
+
+use crate::fgd::write_fgd;
+
 use super::*;
 
 /// Errors that can occur when getting the [default TrenchBroom game config path](https://trenchbroom.github.io/manual/latest/#game_configuration_files).
@@ -53,7 +57,7 @@ impl TrenchBroomConfig {
 	/// Writes the configuration into the [default TrenchBroom game config path](https://trenchbroom.github.io/manual/latest/#game_configuration_files).
 	///
 	/// If you want to customize the path, use [`write_game_config`](Self::write_game_config) instead.
-	pub fn write_game_config_to_default_directory(&self) -> Result<(), DefaultTrenchBroomGameConfigError> {
+	pub fn write_game_config_to_default_directory(&self, type_registry: &TypeRegistry) -> Result<(), DefaultTrenchBroomGameConfigError> {
 		let path = self.get_default_trenchbroom_game_config_path()?;
 		if !path.exists() {
 			let err = fs::create_dir_all(&path);
@@ -62,7 +66,7 @@ impl TrenchBroomConfig {
 			}
 		}
 
-		if let Err(err) = self.write_game_config(&path) {
+		if let Err(err) = self.write_game_config(&path, type_registry) {
 			return Err(DefaultTrenchBroomGameConfigError::WriteError { error: err, path });
 		}
 
@@ -177,7 +181,7 @@ impl TrenchBroomConfig {
 	/// Writes the game configuration into a directory, it is your choice when to do this in your application, and where you want to save the config to.
 	///
 	/// If you have a standard TrenchBroom installation, you can use [`write_game_config_to_default_directory`](Self::write_game_config_to_default_directory) instead to use the default location.
-	pub fn write_game_config(&self, directory: impl AsRef<Path>) -> io::Result<()> {
+	pub fn write_game_config(&self, directory: impl AsRef<Path>, type_registry: &TypeRegistry) -> io::Result<()> {
 		if self.name.is_empty() {
 			return Err(io::Error::other(
 				"Please set a name for your TrenchBroom config. \
@@ -255,7 +259,7 @@ impl TrenchBroomConfig {
 		//// FGD
 		//////////////////////////////////////////////////////////////////////////////////
 
-		fs::write(folder.join(format!("{}.fgd", self.name)), self.to_fgd())?;
+		fs::write(folder.join(format!("{}.fgd", self.name)), write_fgd(type_registry))?;
 
 		info!("Successfully wrote TrenchBroom game config to {}", folder.display());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,8 +29,6 @@ pub(crate) use prelude::*;
 // Re-exports
 pub use anyhow;
 pub use bevy_materialize;
-#[cfg(feature = "auto_register")]
-pub use inventory;
 
 pub struct TrenchBroomPlugin(pub TrenchBroomConfig);
 
@@ -47,15 +45,6 @@ impl Plugin for TrenchBroomPlugin {
 
 		#[cfg(feature = "client")]
 		app.add_plugins(special_textures::SpecialTexturesPlugin);
-
-		if config.register_entity_class_types {
-			let type_registry = app.world().resource::<AppTypeRegistry>();
-			let mut type_registry = type_registry.write();
-			for class in config.class_iter() {
-				type_registry.add_registration((class.get_type_registration)());
-				(class.register_type_dependencies)(&mut type_registry);
-			}
-		}
 
 		#[cfg(feature = "client")]
 		if config.lightmap_exposure.is_some() {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -27,7 +27,7 @@ pub use qbsp::{
 pub use crate::{
 	TrenchBroomPlugin, TrenchBroomServer,
 	class::{
-		QuakeClass,
+		QuakeClass, ReflectQuakeClass,
 		builtin::{Target, Targetable},
 		spawn_util::*,
 	},

--- a/src/qmap/loader.rs
+++ b/src/qmap/loader.rs
@@ -8,20 +8,29 @@ use class::QuakeClassType;
 use config::TextureLoadView;
 use geometry::{BrushList, Brushes, GeometryProviderMeshView, MapGeometryTexture};
 
-use crate::class::QuakeClassSpawnView;
+use crate::class::{QuakeClassSpawnView, generate_class_map};
 
 use super::*;
 
 pub struct QuakeMapLoader {
 	pub asset_server: AssetServer,
 	pub tb_server: TrenchBroomServer,
+	pub type_registry: AppTypeRegistry,
 }
 impl FromWorld for QuakeMapLoader {
 	fn from_world(world: &mut World) -> Self {
 		Self {
 			asset_server: world.resource::<AssetServer>().clone(),
 			tb_server: world.resource::<TrenchBroomServer>().clone(),
+			type_registry: world.resource::<AppTypeRegistry>().clone(),
 		}
+	}
+}
+impl QuakeMapLoader {
+	/// The type registry cannot be read in an async context because the read lock doesn't implement Send. (Still not really sure why)
+	/// And so, we have to use a non-async function to do this.
+	pub fn generate_class_map(&self) -> HashMap<&'static str, &'static class::ErasedQuakeClass> {
+		generate_class_map(&self.type_registry.read())
 	}
 }
 impl AssetLoader for QuakeMapLoader {
@@ -35,7 +44,7 @@ impl AssetLoader for QuakeMapLoader {
 		_settings: &Self::Settings,
 		load_context: &mut bevy::asset::LoadContext,
 	) -> impl ConditionalSendFuture<Output = Result<Self::Asset, Self::Error>> {
-		Box::pin(async {
+		Box::pin(async move {
 			let mut input = String::new();
 			reader.read_to_string(&mut input).await?;
 
@@ -67,9 +76,11 @@ impl AssetLoader for QuakeMapLoader {
 				}
 			}
 
+			let class_map = self.generate_class_map();
+
 			for (map_entity_idx, map_entity) in entities.iter().enumerate() {
 				let Some(classname) = map_entity.properties.get("classname") else { continue };
-				let Some(class) = self.tb_server.config.get_class(classname) else {
+				let Some(class) = class_map.get(classname.as_str()).copied() else {
 					if !self.tb_server.config.suppress_invalid_entity_definitions {
 						error!("No class found for classname `{classname}` on entity {map_entity_idx}");
 					}
@@ -84,6 +95,8 @@ impl AssetLoader for QuakeMapLoader {
 					.apply_spawn_fn_recursive(&mut QuakeClassSpawnView {
 						config: &self.tb_server.config,
 						src_entity: map_entity,
+						type_registry: &self.type_registry.read(),
+						class_map: &class_map,
 						class,
 						entity: &mut entity,
 						load_context,
@@ -220,6 +233,8 @@ impl AssetLoader for QuakeMapLoader {
 				(self.tb_server.config.global_spawner)(&mut QuakeClassSpawnView {
 					config: &self.tb_server.config,
 					src_entity: map_entity,
+					type_registry: &self.type_registry.read(),
+					class_map: &class_map,
 					class,
 					entity: &mut entity,
 					load_context,


### PR DESCRIPTION
I think this is technically a regression since it adds boilerplate to people using the `auto_register` feature even if they call `register_type::<T>()` automatically since you now need to `#[reflect(QuakeClass)]` along with `Component`.
Still, i think this will be better in the long run, especially if https://github.com/bevyengine/bevy/pull/15030 lands, as this both aligns our separate type registration with Bevy's, reusing their system instead, and also as #89 brought up to prompt this PR, this allows you to more easily register classes in different modules.

Closes #89