### PR TITLE
Lock BSPs behind a feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
         run: cargo clippy --all-targets
       - name: Run cargo clippy without default features
         run: cargo clippy --all-targets --no-default-features
+      - name: Run cargo clippy for bsps
+        run: cargo clippy --all-targets --features bsp
       - name: Run cargo clippy for avian
         run: cargo clippy --all-targets --features avian
       - name: Run cargo clippy for rapier
@@ -93,10 +95,10 @@ jobs:
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - name: Run tests with avian
         run: |
-          cargo test --locked --workspace --all-targets --features bevy/x11 --features avian,client
+          cargo test --locked --workspace --all-targets --features bevy/x11 --features avian,client,bsp
           # Running doc tests separately is a workaround for https://github.com/rust-lang/cargo/issues/6669
           # Setting LD_LIBRARY_PATH is a workaround for https://github.com/TheBevyFlock/bevy_new_2d/pull/318#issuecomment-2585935350
-          LD_LIBRARY_PATH="$(rustc --print target-libdir)" cargo test --locked --workspace --doc --features bevy/x11 --features avian,client
+          LD_LIBRARY_PATH="$(rustc --print target-libdir)" cargo test --locked --workspace --doc --features bevy/x11 --features avian,client,bsp
 
   # Check that the crate builds for web.
   build-web:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ serde = { version = "1", features = [
 thiserror = "2.0"
 disjoint-sets = "0.4.2"
 # qbsp = { version = "0.4", features = ["bevy_reflect", "serde"] }
-qbsp = { git = "https://github.com/Noxmore/qbsp.git", rev = "cc0b9e3", features = ["bevy_reflect", "serde"] }
+qbsp = { git = "https://github.com/Noxmore/qbsp.git", rev = "cc0b9e3", features = ["bevy_reflect", "serde"], optional = true }
 nil.workspace = true
 ndshape = "0.3.0"
 strum = { version = "0.27", features = ["derive"] }
@@ -82,6 +82,7 @@ default = ["client"]
 client = ["bevy/bevy_pbr", "bevy_materialize/bevy_pbr"]
 rapier = ["dep:bevy_rapier3d"]
 avian = ["dep:avian3d"]
+bsp = ["dep:qbsp"]
 
 [patch.crates-io]
 avian3d = { git = "https://github.com/Jondolf/avian.git", branch = "main" }

--- a/ci/full_check.bat
+++ b/ci/full_check.bat
@@ -10,6 +10,9 @@ cargo clippy --all-targets || exit /b 1
 echo Run cargo clippy without default features
 cargo clippy --all-targets --no-default-features || exit /b 1
 
+echo Run cargo clippy for bsps
+cargo clippy --all-targets --features bsp || exit /b 1
+
 echo Run cargo clippy for avian
 cargo clippy --all-targets --features avian || exit /b 1
 
@@ -18,8 +21,8 @@ cargo clippy --all-targets --features rapier || exit /b 1
 
 
 echo Run tests with avian
-cargo test --locked --workspace --features avian,client || exit /b 1
-cargo test --locked --workspace --doc --features avian,client || exit /b 1
+cargo test --locked --workspace --features avian,client,bsp || exit /b 1
+cargo test --locked --workspace --doc --features avian,client,bsp || exit /b 1
 
 
 echo Run cargo doc with default features

--- a/ci/full_check.sh
+++ b/ci/full_check.sh
@@ -14,6 +14,9 @@ cargo clippy --all-targets
 { echo; echo; echo "Run cargo clippy without default features"; } 2> /dev/null
 cargo clippy --all-targets --no-default-features
 
+{ echo; echo; echo "Run cargo clippy for bsps"; } 2> /dev/null
+cargo clippy --all-targets --features bsp
+
 { echo; echo; echo "Run cargo clippy for avian"; } 2> /dev/null
 cargo clippy --all-targets --features avian
 
@@ -22,8 +25,8 @@ cargo clippy --all-targets --features rapier
 
 
 { echo; echo; echo "Run tests with avian"; } 2> /dev/null
-cargo test --locked --workspace --features bevy/x11 --features avian,client
-LD_LIBRARY_PATH="$(rustc --print target-libdir)" cargo test --locked --workspace --doc --features bevy/x11 --features avian,client
+cargo test --locked --workspace --features bevy/x11 --features avian,client,bsp
+LD_LIBRARY_PATH="$(rustc --print target-libdir)" cargo test --locked --workspace --doc --features bevy/x11 --features avian,client,bsp
 
 
 { echo; echo; echo "Run cargo doc with default features"; } 2> /dev/null

--- a/example/avian/Cargo.toml
+++ b/example/avian/Cargo.toml
@@ -17,6 +17,7 @@ avian3d = { version = "0.2" }
 bevy_trenchbroom = { path = "../..", default-features = false, features = [
 	"avian",
 	"client",
+	"bsp"
 ] }
 bevy_flycam = { workspace = true }
 bevy-inspector-egui = { workspace = true }

--- a/example/bsp_loading/Cargo.toml
+++ b/example/bsp_loading/Cargo.toml
@@ -13,7 +13,7 @@ doc = false
 
 [dependencies]
 bevy.workspace = true
-bevy_trenchbroom = { path = "../..", default-features = false }
+bevy_trenchbroom = { path = "../..", default-features = false, features = ["bsp"] }
 bevy_flycam = { workspace = true, optional = true }
 bevy-inspector-egui = { workspace = true, optional = true }
 nil.workspace = true

--- a/example/map_loading/main.rs
+++ b/example/map_loading/main.rs
@@ -95,9 +95,7 @@ fn main() {
 			}),
 			ClientPlugin,
 		))
-		.add_plugins(TrenchBroomPlugin(
-			TrenchBroomConfig::new("bevy_trenchbroom_example").no_bsp_lighting(true),
-		))
+		.add_plugins(TrenchBroomPlugin(TrenchBroomConfig::new("bevy_trenchbroom_example")))
 		.register_type::<Worldspawn>()
 		.register_type::<Cube>()
 		.register_type::<Mushroom>()

--- a/readme.md
+++ b/readme.md
@@ -249,7 +249,7 @@ fn spawn_test_map(
 
 ## BSP
 
-`bevy_trenchbroom` supports BSP loading via the [qbsp](https://github.com/Noxmore/qbsp) crate.
+`bevy_trenchbroom` supports BSP loading via the [qbsp](https://github.com/Noxmore/qbsp) crate when the `bsp` feature is activated.
 
 Specifically, it is oriented around using the latest [ericw-tools](https://ericwa.github.io/ericw-tools/) as the compiler, including some base classes such as `BspWorldspawn`, `BspSolidEntity`, and `BspLight` that contain various compiler-specific properties.
 

--- a/src/class/mod.rs
+++ b/src/class/mod.rs
@@ -224,7 +224,7 @@ impl<T: QuakeClass> FromType<T> for ReflectQuakeClass {
 	}
 }
 
-#[cfg(feature = "client")]
+#[cfg(all(feature = "client", feature = "bsp"))]
 #[test]
 fn derives_from() {
 	use crate::bsp::base_classes::*;

--- a/src/class/spawn_util.rs
+++ b/src/class/spawn_util.rs
@@ -129,21 +129,17 @@ fn preloading() {
 			TrenchBroomConfig::default().suppress_invalid_entity_definitions(true),
 		))
 		.register_type::<Mushroom>()
-		.register_type::<bevy::pbr::LightProbe>()
 		.register_type::<Visibility>()
 		.register_type::<InheritedVisibility>()
 		.register_type::<ViewVisibility>()
-		.register_type::<crate::bsp::lighting::AnimatedLightingHandle>()
 		.register_type::<PreloadedAssets>()
 		.register_type::<MeshMaterial3d<StandardMaterial>>()
 		.register_type::<Aabb>()
 		.register_type::<VisibilityClass>()
 		.init_asset::<Image>()
 		.init_asset::<StandardMaterial>()
-		.init_asset::<crate::bsp::lighting::AnimatedLighting>()
-		.init_asset::<crate::bsp::BspBrushesAsset>()
-		.init_asset::<crate::bsp::Bsp>()
-		.init_asset_loader::<crate::bsp::loader::BspLoader>()
+		.init_asset::<crate::qmap::QuakeMap>()
+		.init_asset_loader::<crate::qmap::loader::QuakeMapLoader>()
 		.add_systems(Startup, setup)
 		.add_systems(Update, spawn_scene)
 		.add_systems(Last, exit)
@@ -156,7 +152,7 @@ fn preloading() {
 	struct MapScene(Handle<Scene>);
 
 	fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-		let handle = smol::block_on(async { asset_server.load_untyped_async("maps/example.bsp#Scene").await.expect("Asset error") });
+		let handle = smol::block_on(async { asset_server.load_untyped_async("maps/example.map#Scene").await.expect("Asset error") });
 
 		// This is set back so that the Scene can be put in Assets<Scene>, otherwise validate_scene will fail with it.
 		commands.insert_resource(MapScene(handle.try_typed::<Scene>().unwrap()));

--- a/src/config/main_impl.rs
+++ b/src/config/main_impl.rs
@@ -1,4 +1,6 @@
 use crate::{class::builtin::{read_rotation_from_entity, read_translation_from_entity}, util::AssetServerExistsExt};
+#[cfg(feature = "bsp")]
+use bsp::GENERIC_MATERIAL_PREFIX;
 
 use super::*;
 
@@ -34,6 +36,7 @@ impl TrenchBroomConfig {
 		self.texture_sampler(ImageSampler::linear().repeat())
 	}
 
+	#[cfg(feature = "bsp")]
 	pub fn default_compute_lightmap_settings() -> ComputeLightmapSettings {
 		ComputeLightmapSettings {
 			special_lighting_color: [75; 3],
@@ -93,10 +96,12 @@ impl TrenchBroomConfig {
 		}
 	}
 
+	#[cfg(feature = "bsp")]
 	pub fn load_embedded_texture_fn(mut self, provider: impl FnOnce(Arc<LoadEmbeddedTextureFn>) -> Arc<LoadEmbeddedTextureFn>) -> Self {
 		self.load_embedded_texture.set(provider);
 		self
 	}
+	#[cfg(feature = "bsp")]
 	pub fn default_load_embedded_texture<'a>(
 		#[allow(unused_mut)] mut view: EmbeddedTextureLoadView<'a, '_>,
 	) -> BoxedFuture<'a, Handle<GenericMaterial>> {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -13,7 +13,6 @@ use bevy::{
 	image::ImageSampler,
 	tasks::BoxedFuture,
 };
-use bsp::GENERIC_MATERIAL_PREFIX;
 use fgd::FgdType;
 use geometry::{GeometryProviderFn, GeometryProviderView};
 use qmap::QuakeMapEntities;
@@ -83,9 +82,16 @@ pub struct TrenchBroomConfig {
 	/// If TrenchBroom can't find this palette file, all WAD textures will be black. If `bevy_trenchbroom` can't find the file, it will default to [`QUAKE_PALETTE`].
 	///
 	/// (Default: "palette.lmp")
+	#[cfg(feature = "bsp")]
 	#[builder(into)]
-	#[default("palette.lmp".into())] // TODO
+	#[default("palette.lmp".into())]
 	pub texture_pallette: PathBuf,
+	/// For BSPs.
+	#[cfg(not(feature = "bsp"))]
+	#[builder(into)]
+	#[default("palette.lmp".into())]
+	pub texture_pallette: PathBuf,
+
 	/// Patterns to match to exclude certain texture files from showing up in-editor. (Default: [`TrenchBroomConfig::default_texture_exclusions`]).
 	#[builder(into)]
 	#[default(Self::default_texture_exclusions())]
@@ -145,10 +151,10 @@ pub struct TrenchBroomConfig {
 	pub generic_material_extensions: Vec<String>,
 
 	/// If `Some`, sets the lightmap exposure on any `StandardMaterial` loaded. (Default: Some(10,000))
-	#[cfg(feature = "client")]
+	#[cfg(all(feature = "client", feature = "bsp"))]
 	#[default(Some(10_000.))]
 	pub lightmap_exposure: Option<f32>,
-	#[cfg(feature = "client")]
+	#[cfg(all(feature = "client", feature = "bsp"))]
 	#[default(500.)]
 	pub default_irradiance_volume_intensity: f32,
 	/// Multipliers to the colors of BSP loaded irradiance volumes depending on direction.
@@ -157,7 +163,7 @@ pub struct TrenchBroomConfig {
 	/// This fakes it, making objects within look a little nicer.
 	///
 	/// (Default: [`IrradianceVolumeMultipliers::SLIGHT_SHADOW`])
-	#[cfg(feature = "client")]
+	#[cfg(all(feature = "client", feature = "bsp"))]
 	#[default(IrradianceVolumeMultipliers::SLIGHT_SHADOW)]
 	pub irradiance_volume_multipliers: IrradianceVolumeMultipliers,
 
@@ -165,8 +171,10 @@ pub struct TrenchBroomConfig {
 	pub suppress_invalid_entity_definitions: bool,
 
 	/// Whether to disable bsp lighting (lightmaps and irradiance volumes). This is for rendering backends where these aren't supported like OpenGL.
+	#[cfg(feature = "bsp")]
 	pub no_bsp_lighting: bool,
 
+	#[cfg(feature = "bsp")]
 	#[builder(skip)]
 	#[default(Hook(Arc::new(Self::default_load_embedded_texture)))]
 	pub load_embedded_texture: Hook<LoadEmbeddedTextureFn>,
@@ -179,6 +187,7 @@ pub struct TrenchBroomConfig {
 	/// If [`Some`], embedded textures with names starting with `+<0..9>` will become animated, going to the next number in the range, and if it doesn't exist, looping back around to 0.
 	///
 	/// (Default: `Some(5)`)
+	#[cfg(feature = "bsp")]
 	#[default(Some(5.))]
 	pub embedded_texture_animation_fps: Option<f32>,
 
@@ -187,20 +196,21 @@ pub struct TrenchBroomConfig {
 	/// Using the material provided by the contained function, the left side being the foreground, and right side the background.
 	///
 	/// (Default: `Some(QuakeSkyMaterial::default)`)
-	#[cfg(feature = "client")]
+	#[cfg(all(feature = "client", feature = "bsp"))]
 	#[default(Some(default))]
 	pub embedded_quake_sky_material: Option<fn() -> QuakeSkyMaterial>,
 
 	/// If [`Some`], embedded textures with names that start with `*` will use [`LiquidMaterial`], and will abide by the `water_alpha` worldspawn key.
 	///
 	/// (Default: `Some(QuakeSkyMaterial::default)`)
-	#[cfg(feature = "client")]
+	#[cfg(all(feature = "client", feature = "bsp"))]
 	#[default(Some(default))]
 	pub embedded_liquid_material: Option<fn() -> LiquidMaterialExt>,
 
 	/// If `true`, embedded textures with names starting with `{` will be given the alpha mode [`Mask(0.5)`](AlphaMode::Mask), and pixels with the index value `255` will be turned transparent.
 	///
 	/// (Default: `true`)
+	#[cfg(feature = "bsp")]
 	#[default(true)]
 	pub embedded_texture_cutouts: bool,
 
@@ -225,10 +235,12 @@ pub struct TrenchBroomConfig {
 	/// NOTE: `special_lighting_color` is set to gray (`75`) by default instead of white (`255`), because otherwise all textures with it look way too bright and washed out, not sure why.
 	///
 	/// (Default: [`Self::default_compute_lightmap_settings`])
+	#[cfg(feature = "bsp")]
 	#[default(Self::default_compute_lightmap_settings())]
 	pub compute_lightmap_settings: ComputeLightmapSettings,
 
 	/// `qbsp` settings when parsing BSP files.
+	#[cfg(feature = "bsp")]
 	pub bsp_parse_settings: BspParseSettings,
 
 	/// Entity spawners that get run on every single entity (after the regular spawners), regardless of classname. (Default: [`TrenchBroomConfig::default_global_spawner`])
@@ -259,6 +271,7 @@ pub struct TrenchBroomConfig {
 	/// If `true`, lightmaps spawned from BSPs will use bicubic filtering. (Default: `false`)
 	///
 	/// NOTE: It's recommended you add a pixel of padding in [`compute_lightmap_settings`](Self::compute_lightmap_settings), otherwise there will be obvious lightmap leaking.
+	#[cfg(feature = "bsp")]
 	pub bicubic_lightmap_filtering: bool,
 
 	/// Whether brush meshes are kept around in memory after they're sent to the GPU. Default: [`RenderAssetUsages::all`] (kept around)
@@ -266,6 +279,7 @@ pub struct TrenchBroomConfig {
 	pub brush_mesh_asset_usages: RenderAssetUsages,
 
 	/// Whether BSP loaded textures and lightmaps are kept around in memory after they're sent to the GPU. Default: [`RenderAssetUsages::RENDER_WORLD`] (not kept around)
+	#[cfg(feature = "bsp")]
 	#[default(RenderAssetUsages::RENDER_WORLD)]
 	pub bsp_textures_asset_usages: RenderAssetUsages,
 }

--- a/src/fgd.rs
+++ b/src/fgd.rs
@@ -362,6 +362,7 @@ impl From<Srgb> for Color {
 	}
 }
 
+#[cfg(feature = "bsp")]
 impl FgdType for LightmapStyle {
 	const FGD_IS_QUOTED: bool = u8::FGD_IS_QUOTED;
 	const PROPERTY_TYPE: QuakeClassPropertyType = u8::PROPERTY_TYPE;

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -1,7 +1,8 @@
 use bevy_mesh::VertexAttributeValues;
 use brush::Brush;
+#[cfg(feature = "bsp")]
 use bsp::BspBrushesAsset;
-#[cfg(feature = "client")]
+#[cfg(all(feature = "client", feature = "bsp"))]
 use bsp::lighting::{AnimatedLighting, AnimatedLightingHandle};
 use qmap::QuakeMapEntity;
 
@@ -23,8 +24,6 @@ impl Plugin for GeometryPlugin {
 }
 
 /// Contains the brushes that a solid entity is made of.
-///
-/// Unless [`Brushes::Bsp`], entities with this component have meshes generated for them at runtime.
 #[derive(Component, Reflect, Debug, Clone)]
 #[reflect(Component)]
 #[require(Transform)]
@@ -36,6 +35,7 @@ pub enum Brushes {
 	/// Reads an asset instead for completely static geometry.
 	Shared(Handle<BrushList>),
 	/// Used with the `BRUSHLIST` BSPX lump. Collision only.
+	#[cfg(feature = "bsp")]
 	Bsp(Handle<BspBrushesAsset>),
 }
 
@@ -53,9 +53,10 @@ impl std::ops::Deref for BrushList {
 pub struct MapGeometryTexture {
 	pub name: String,
 	pub material: Handle<GenericMaterial>,
-	#[cfg(feature = "client")]
+	#[cfg(all(feature = "client", feature = "bsp"))]
 	pub lightmap: Option<Handle<AnimatedLighting>>,
 	/// If the texture should be full-bright
+	#[cfg(feature = "bsp")]
 	pub flags: BspTexFlags,
 }
 
@@ -206,7 +207,7 @@ impl GeometryProvider {
 	}
 
 	/// Inserts lightmaps if available.
-	#[cfg(feature = "client")]
+	#[cfg(all(feature = "client", feature = "bsp"))]
 	pub fn with_lightmaps(self) -> Self {
 		self.push(|view| {
 			for mesh_view in &view.meshes {
@@ -218,7 +219,7 @@ impl GeometryProvider {
 			}
 		})
 	}
-	#[cfg(not(feature = "client"))]
+	#[cfg(all(not(feature = "client"), feature = "bsp"))]
 	pub fn with_lightmaps(self) -> Self {
 		self
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ compile_error!("can only have one collider backend enabled");
 extern crate self as bevy_trenchbroom;
 
 pub mod brush;
+#[cfg(feature = "bsp")]
 pub mod bsp;
 pub mod class;
 pub mod config;
@@ -46,7 +47,7 @@ impl Plugin for TrenchBroomPlugin {
 		#[cfg(feature = "client")]
 		app.add_plugins(special_textures::SpecialTexturesPlugin);
 
-		#[cfg(feature = "client")]
+		#[cfg(all(feature = "client", feature = "bsp"))]
 		if config.lightmap_exposure.is_some() {
 			app.add_systems(Update, Self::set_lightmap_exposure);
 		}
@@ -61,6 +62,7 @@ impl Plugin for TrenchBroomPlugin {
 				class::QuakeClassPlugin,
 				config::ConfigPlugin,
 				qmap::QuakeMapPlugin,
+				#[cfg(feature = "bsp")]
 				bsp::BspPlugin,
 				geometry::GeometryPlugin,
 				util::UtilPlugin,
@@ -72,7 +74,7 @@ impl Plugin for TrenchBroomPlugin {
 	}
 }
 impl TrenchBroomPlugin {
-	#[cfg(feature = "client")]
+	#[cfg(all(feature = "client", feature = "bsp"))]
 	pub fn set_lightmap_exposure(
 		mut asset_events: EventReader<AssetEvent<StandardMaterial>>,
 		mut standard_materials: ResMut<Assets<StandardMaterial>>,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -2,7 +2,7 @@
 pub(crate) use crate::util::{Aabb, Mesh3d};
 pub(crate) use anyhow::anyhow;
 pub(crate) use bevy::math::*;
-#[cfg(feature = "client")]
+#[cfg(all(feature = "client", feature = "bsp"))]
 pub(crate) use bevy::pbr::irradiance_volume::IrradianceVolume;
 pub(crate) use bevy::platform::collections::HashMap;
 pub(crate) use bevy::prelude::*;
@@ -13,17 +13,26 @@ pub(crate) use default_struct_builder::*;
 pub(crate) use itertools::*;
 pub(crate) use nil::prelude::*;
 pub(crate) use nil::std_prelude::*;
+#[cfg(feature = "bsp")]
 pub(crate) use qbsp::prelude::*;
 pub(crate) use serde::*;
 pub(crate) use thiserror::Error;
 
 pub use bevy_materialize::prelude::*;
+#[cfg(feature = "bsp")]
 pub use qbsp::{
 	self, Palette, QUAKE_PALETTE,
 	data::bsp::{BspTexFlags, LightmapStyle},
 	mesh::lightmap::{ComputeLightmapSettings, LightmapAtlas},
 };
 
+#[cfg(all(feature = "client", feature = "bsp"))]
+pub use crate::bsp::{
+	lighting::{LightingAnimator, LightingAnimators},
+	loader::IrradianceVolumeMultipliers,
+};
+#[cfg(feature = "client")]
+pub use crate::special_textures::{LiquidMaterial, LiquidMaterialExt, QuakeSkyMaterial};
 pub use crate::{
 	TrenchBroomPlugin, TrenchBroomServer,
 	class::{
@@ -35,14 +44,6 @@ pub use crate::{
 	geometry::{GeometryProvider, GeometryProviderView},
 	qmap::QuakeMapEntity,
 	util::IsSceneWorld,
-};
-#[cfg(feature = "client")]
-pub use crate::{
-	bsp::{
-		lighting::{LightingAnimator, LightingAnimators},
-		loader::IrradianceVolumeMultipliers,
-	},
-	special_textures::{LiquidMaterial, LiquidMaterialExt, QuakeSkyMaterial},
 };
 
 pub use bevy_trenchbroom_macros::*;

--- a/src/qmap/loader.rs
+++ b/src/qmap/loader.rs
@@ -185,8 +185,9 @@ impl AssetLoader for QuakeMapLoader {
 							MapGeometryTexture {
 								name: texture.s(),
 								material,
-								#[cfg(feature = "client")]
+								#[cfg(all(feature = "client", feature = "bsp"))]
 								lightmap: None,
+								#[cfg(feature = "bsp")]
 								flags: BspTexFlags::Normal,
 							},
 						));

--- a/src/qmap/mod.rs
+++ b/src/qmap/mod.rs
@@ -27,7 +27,7 @@ pub struct QuakeMap {
 	pub entities: QuakeMapEntities,
 }
 
-/// All the entities stored in a quake map, whether [`QuakeMap`] or [`Bsp`](bsp::Bsp).
+/// All the entities stored in a quake map, whether `.map` or `.bsp`.
 #[derive(Reflect, Debug, Clone, Default, Deref, DerefMut)]
 pub struct QuakeMapEntities(pub Vec<QuakeMapEntity>);
 impl QuakeMapEntities {
@@ -67,6 +67,10 @@ pub struct QuakeMapEntity {
 	/// If the map entity is a [`Solid`](crate::class::QuakeClassType::Solid) entity, this will contain the brushes making it up.
 	///
 	/// NOTE: If loading from a BSP, this will always be empty. Instead, use the `BRUSHLIST` BSPX lump stored within [`BspModel`](crate::bsp::BspModel).
+	#[cfg(feature = "bsp")]
+	pub brushes: Vec<Brush>,
+	/// If the map entity is a [`Solid`](crate::class::QuakeClassType::Solid) entity, this will contain the brushes making it up.
+	#[cfg(not(feature = "bsp"))]
 	pub brushes: Vec<Brush>,
 }
 

--- a/src/special_textures.rs
+++ b/src/special_textures.rs
@@ -1,11 +1,18 @@
 use bevy::{
 	asset::embedded_asset,
-	image::TextureFormatPixelInfo,
 	pbr::{ExtendedMaterial, MaterialExtension},
-	render::render_resource::{AsBindGroup, Extent3d, TextureDimension},
+	render::render_resource::AsBindGroup,
 };
+#[cfg(feature = "bsp")]
+use bevy::{
+	image::TextureFormatPixelInfo,
+	render::render_resource::{Extent3d, TextureDimension},
+};
+#[cfg(feature = "bsp")]
 use bevy_materialize::animation::{GenericMaterialAnimationState, ImagesAnimation, MaterialAnimations};
+#[cfg(feature = "bsp")]
 use bsp::TEXTURE_PREFIX;
+#[cfg(feature = "bsp")]
 use config::EmbeddedTextureLoadView;
 
 use crate::*;
@@ -25,6 +32,7 @@ impl Plugin for SpecialTexturesPlugin {
 }
 
 /// If [`TrenchBroomConfig`] contains [Quake special textures](https://quakewiki.org/wiki/Textures), this attempts to load them using the material provided as a base.
+#[cfg(feature = "bsp")]
 pub fn load_special_texture(view: &mut EmbeddedTextureLoadView, material: &StandardMaterial) -> Option<GenericMaterial> {
 	// We save a teeny tiny bit of time by only cloning if we need to :)
 	let mut material = material.clone();


### PR DESCRIPTION
Makes the code base a bit more complicated, but allows for things like #97, and removes bloat for users who do not use bsps.