### PR TITLE
Make `TrenchBroomPlugin` into a plugin group.

### DIFF
--- a/example/bsp_loading/main.rs
+++ b/example/bsp_loading/main.rs
@@ -115,7 +115,7 @@ fn main() {
 			}),
 			ClientPlugin,
 		))
-		.add_plugins(TrenchBroomPlugin(
+		.add_plugins(TrenchBroomPlugins(
 			TrenchBroomConfig::new("bevy_trenchbroom_example")
 				.suppress_invalid_entity_definitions(true)
 				.bicubic_lightmap_filtering(true)

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ use bevy_trenchbroom::prelude::*;
 fn main() {
     App::new()
         // ...
-        .add_plugins(TrenchBroomPlugin(
+        .add_plugins(TrenchBroomPlugins(
             // Here you can customize the resulting bevy_trenchbroom
             // and game configuration with a builder syntax
             TrenchBroomConfig::new("your_game_name")

--- a/src/bsp/mod.rs
+++ b/src/bsp/mod.rs
@@ -19,10 +19,6 @@ impl Plugin for BspPlugin {
 	fn build(&self, app: &mut App) {
 		#[rustfmt::skip]
 		app
-			.add_plugins((
-				base_classes::BspBaseClassesPlugin,
-			))
-
 			.init_asset::<BspBrushesAsset>()
 			.init_asset::<Bsp>()
 			.init_asset_loader::<BspLoader>()

--- a/src/class/mod.rs
+++ b/src/class/mod.rs
@@ -13,7 +13,6 @@ impl Plugin for QuakeClassPlugin {
 	fn build(&self, app: &mut App) {
 		#[rustfmt::skip]
 		app
-			.add_plugins(builtin::BuiltinClassesPlugin)
 			.register_type::<PreloadedAssets>()
 		;
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub mod qmap;
 pub mod special_textures;
 pub mod util;
 
+use bevy::app::PluginGroupBuilder;
 use bevy_materialize::MaterializeMarkerPlugin;
 pub(crate) use prelude::*;
 
@@ -30,48 +31,53 @@ pub(crate) use prelude::*;
 pub use anyhow;
 pub use bevy_materialize;
 
-pub struct TrenchBroomPlugin(pub TrenchBroomConfig);
+pub struct TrenchBroomPlugins(pub TrenchBroomConfig);
 
-impl Plugin for TrenchBroomPlugin {
+impl PluginGroup for TrenchBroomPlugins {
+	fn build(self) -> PluginGroupBuilder {
+		let builder = PluginGroupBuilder::start::<Self>()
+			.add(CorePlugin(self.0))
+			.add(fgd::FgdPlugin)
+			.add(class::QuakeClassPlugin)
+			.add(class::builtin::BuiltinClassesPlugin)
+			.add(config::ConfigPlugin)
+			.add(qmap::QuakeMapPlugin)
+			.add(bsp::BspPlugin)
+			.add(bsp::base_classes::BspBaseClassesPlugin)
+			.add(geometry::GeometryPlugin)
+			.add(util::UtilPlugin);
+
+		// Have to use let here because "attributes on expressions are experimental"
+		#[cfg(any(feature = "rapier", feature = "avian"))]
+		let builder = builder.add(physics::PhysicsPlugin);
+
+		#[cfg(feature = "client")]
+		let builder = builder.add(special_textures::SpecialTexturesPlugin);
+
+		builder
+	}
+}
+
+pub struct CorePlugin(pub TrenchBroomConfig);
+
+impl Plugin for CorePlugin {
 	fn build(&self, app: &mut App) {
-		let TrenchBroomPlugin(config) = self;
+		let CorePlugin(config) = self;
 
 		if !app.is_plugin_added::<MaterializeMarkerPlugin>() {
 			app.add_plugins(MaterializePlugin::new(TomlMaterialDeserializer));
 		}
-
-		#[cfg(any(feature = "rapier", feature = "avian"))]
-		app.add_plugins(physics::PhysicsPlugin);
-
-		#[cfg(feature = "client")]
-		app.add_plugins(special_textures::SpecialTexturesPlugin);
 
 		#[cfg(feature = "client")]
 		if config.lightmap_exposure.is_some() {
 			app.add_systems(Update, Self::set_lightmap_exposure);
 		}
 
-		#[rustfmt::skip]
-		app
-			// I'd rather not clone here, but i only have a reference to self
-			.insert_resource(TrenchBroomServer::new(config.clone()))
-
-			.add_plugins((
-				fgd::FgdPlugin,
-				class::QuakeClassPlugin,
-				config::ConfigPlugin,
-				qmap::QuakeMapPlugin,
-				bsp::BspPlugin,
-				geometry::GeometryPlugin,
-				util::UtilPlugin,
-			))
-		;
-
-		#[cfg(not(feature = "client"))]
-		app.init_asset::<Mesh>().register_type::<Mesh3d>().register_type::<Aabb>();
+		// I'd rather not clone here, but i only have a reference to self
+		app.insert_resource(TrenchBroomServer::new(config.clone()));
 	}
 }
-impl TrenchBroomPlugin {
+impl CorePlugin {
 	#[cfg(feature = "client")]
 	pub fn set_lightmap_exposure(
 		mut asset_events: EventReader<AssetEvent<StandardMaterial>>,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -25,7 +25,7 @@ pub use qbsp::{
 };
 
 pub use crate::{
-	TrenchBroomPlugin, TrenchBroomServer,
+	TrenchBroomPlugins, TrenchBroomServer,
 	class::{
 		QuakeClass, ReflectQuakeClass,
 		builtin::{Target, Targetable},

--- a/src/util.rs
+++ b/src/util.rs
@@ -13,7 +13,7 @@ pub struct UtilPlugin;
 impl Plugin for UtilPlugin {
 	fn build(&self, #[allow(unused)] app: &mut App) {
 		#[cfg(not(feature = "client"))]
-		app.register_type::<Mesh3d>().register_type::<Aabb>();
+		app.init_asset::<Mesh>().register_type::<Mesh3d>().register_type::<Aabb>();
 
 		#[rustfmt::skip]
 		app


### PR DESCRIPTION
Closes #74 

Along with #99 and #91, this will make it easier to add and optionally disable automatically-registered point/solid classes