### PR TITLE
Add double-precision support for Avian

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ bevy = { version = "0.16", default-features = false, features = [
 ] } # For examples
 nil = "0.15"
 enumflags2 = "0.7"
-avian3d = "0.3"
+avian3d = { version = "0.3", default-features = false, features = ["3d", "collider-from-mesh", "debug-plugin", "parallel"]}
 bevy_rapier3d = "0.30"
 example_commons = { path = "example/example_commons" }
 
@@ -72,11 +72,12 @@ atomicow = "1.1.0" # For dummy LoadContext hack, must stay the same version as B
 bevy_fix_gltf_coordinate_system = "0.1"
 
 [dev-dependencies]
-bevy = { version = "0.16", default-features = false, features = [
+bevy = { workspace = true, features = [
 	"png",
 	"bevy_gltf",
 ] } # For tests
 smol = "2"
+avian3d = { workspace = true, features = ["parry-f64", "f64"]}
 
 [features]
 default = ["client"]

--- a/example/physics/Cargo.toml
+++ b/example/physics/Cargo.toml
@@ -14,7 +14,7 @@ doc = false
 [dependencies]
 bevy = { workspace = true, features = ["default"] }
 bevy_rapier3d = { workspace = true, optional = true }
-avian3d = { workspace = true, optional = true }
+avian3d = { workspace = true, optional = true, features = ["parry-f64", "f64"] }
 bevy_trenchbroom = { path = "../..", default-features = false, features = [
 	"client",
 	"bsp"


### PR DESCRIPTION
Does what it says on the tin, this was originally implemented by #109, but this implementation doesn't split `f32` and `f64` into their own features.

It looks like bevy_rapier3d doesn't even support double-precision, even if rapier3d does via rapier3d-f64, so this support doesn't extend to Rapier for now.

Closes #109 