### PR TITLE
Apply `.trim()` to FQD value strings to fix some properties in classic Quake bsps.

### DIFF
--- a/src/class/builtin/mod.rs
+++ b/src/class/builtin/mod.rs
@@ -149,8 +149,9 @@ impl QuakeClass for Visibility {
 			Some("Hidden") => Visibility::Hidden,
 			Some("Visible") => Visibility::Visible,
 			None => Visibility::default(),
-			Some(_) => Err(qmap::QuakeEntityError::PropertyParseError {
+			Some(other) => Err(qmap::QuakeEntityError::PropertyParseError {
 				property: "visibility".s(),
+				value: other.s(),
 				required_type: "Visibility",
 				error: "Must be either `Inherited`, `Hidden`, or `Visible`".s(),
 			})?,

--- a/src/fgd.rs
+++ b/src/fgd.rs
@@ -169,7 +169,7 @@ macro_rules! simple_fgd_type_impl {
 			const PROPERTY_TYPE: QuakeClassPropertyType = QuakeClassPropertyType::$fgd_type($fgd_type_value);
 
 			fn fgd_parse(input: &str) -> anyhow::Result<Self> {
-				Ok(input.parse()?)
+				Ok(input.trim().parse()?)
 			}
 			fn fgd_to_string_unquoted(&self) -> String {
 				self.to_string()

--- a/src/qmap/mod.rs
+++ b/src/qmap/mod.rs
@@ -94,6 +94,7 @@ impl QuakeMapEntity {
 
 		T::fgd_parse(s).map_err(|err| QuakeEntityError::PropertyParseError {
 			property: key.s(),
+			value: s.s(),
 			required_type: type_name::<T>(),
 			error: format!("{err}"),
 		})
@@ -104,9 +105,10 @@ impl QuakeMapEntity {
 pub enum QuakeEntityError {
 	#[error("required property `{property}` not found")]
 	RequiredPropertyNotFound { property: String },
-	#[error("requires property `{property}` to be a valid `{required_type}`. Error: {error}")]
+	#[error("requires property `{property}` to be a valid `{required_type}` (got `{value}`). Error: {error}")]
 	PropertyParseError {
 		property: String,
+		value: String,
 		required_type: &'static str,
 		error: String,
 	},


### PR DESCRIPTION
Also add the value to the `QuakeEntityError::PropertyParseError` error for future reference.

Prior to this fix, `e1m2.bsp` and `e1m4.bsp` (I didn't test more) fail to load with:
```
bevy_asset::server: Failed to load asset '.../maps/e1m2.bsp' with asset
loader 'bevy_asset::server::loaders::InstrumentedAssetLoader<bevy_trenchbroom::bsp::loader::BspLoader>':
spawning entity 468 (light): requires property `light` to be a valid `f32` (got `150 `).
Error: invalid float literal
```