### PR TITLE
Add and Expand Field Attributes to use `#[class(...)]`

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -204,10 +204,75 @@ Examples:
 )]
 #[derive(Default)]
 struct Prop {
-	#[must_set] // A prop wouldn't make much sense without a model!
+	#[class(must_set)] // A prop wouldn't make much sense without a model!
 	model: String,
 }
 ```
+
+### ***Field Attribute: `ignore`***
+Doesn't show the field in-editor as a property.
+
+Examples:
+```rust
+# use bevy::prelude::*;
+# use bevy_trenchbroom::prelude::*;
+#[point_class]
+#[derive(Default)]
+struct CoolClass {
+	foo: i32,
+	
+	#[class(ignore)] /// This doesn't implement FgdType!
+	bar: Vec<f32>,
+}
+
+assert_eq!(CoolClass::CLASS_INFO.properties.len(), 1);
+```
+
+### ***Field Attribute: `rename`***
+Renames the in-editor property. Doesn't rename the Rust field.
+
+Examples:
+```rust
+# use bevy::prelude::*;
+# use bevy_trenchbroom::prelude::*;
+#[point_class]
+#[derive(Default)]
+struct CoolerClass {
+	#[class(rename = "SoCool")]
+	so_cool: u32,
+}
+
+# assert_eq!(CoolerClass::CLASS_INFO.properties[0].name, "SoCool");
+```
+
+### ***Field Attribute: `default`***
+Overrides the default value of the property in TrenchBroom that appears as a hint in the property's UI.
+Note that this does not change the default value of the field, only how it appears in TrenchBroom.
+Without this, the default value of the field is used.
+
+Note: Only integers can be without quotes.
+
+Examples:
+```rust
+# use bevy::prelude::*;
+# use bevy_trenchbroom::prelude::*;
+#[point_class]
+#[derive(Default)]
+struct CoolestClass {
+	#[class(default = 9999)]
+	foo: u32,
+
+	#[class(default = "Default Value!!!")]
+	bar: i32,
+}
+
+# assert_eq!((CoolestClass::CLASS_INFO.properties[0].default_value.unwrap())(), "9999");
+# assert_eq!((CoolestClass::CLASS_INFO.properties[1].default_value.unwrap())(), "\"Default Value!!!\"");
+```
+
+### ***Field Attribute: `title`***
+Sets the TrenchBroom property title of the field. It's a very small change, when a property is selected, the help/info window below it starts with `Property "property_name" (property_name)`. With this set, it becomes `Property "property_name" (Property Title)`.
+
 
 ## Special Properties
 Some properties have special UI in TrenchBroom, this includes

--- a/Migration Guide.md
+++ b/Migration Guide.md
@@ -5,7 +5,7 @@
 	- `#[reflect(QuakeClass, Component)]` is now implied if not specified.
 	- Attributes have been put into the macro body, though they are not needed.
 	- `spawn_hooks` attribute has been renamed to just `hooks`.
-	- The `no_default` field attribute has been renamed to `must_set`.
+	- The `no_default` field attribute has been renamed to `#[class(must_set)`, along with 4 new field attributes.
 	- Here's an example:
 		```rust
 		#[solid_class(

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -26,7 +26,7 @@ use syn::*;
 /// - `must_set` Use on fields you want to output an error if not defined, rather than just being replaced by the field's default value.
 /// - `ignore` Don't include this field in-editor. Sets to default value on spawn.
 /// - `rename = "<name>"` Renames this field in-editor.
-/// - `default = "<default string>"` Overrides the default value of the property in-editor that appears as a hint in the property's UI.
+/// - `default = <default>` Overrides the default value of the property in-editor that appears as a hint in the property's UI.
 /// - `title = "<string>"` Sets the title of the property, in-editor it looks like `property_name (Property Title)`.
 #[proc_macro_attribute]
 pub fn point_class(attr: proc_macro::TokenStream, input: proc_macro::TokenStream) -> proc_macro::TokenStream {
@@ -46,7 +46,7 @@ pub fn point_class(attr: proc_macro::TokenStream, input: proc_macro::TokenStream
 /// - `must_set` Use on fields you want to output an error if not defined, rather than just being replaced by the field's default value.
 /// - `ignore` Don't include this field in-editor. Sets to default value on spawn.
 /// - `rename = "<name>"` Renames this field in-editor.
-/// - `default = "<default string>"` Overrides the default value of the property in-editor that appears as a hint in the property's UI.
+/// - `default = <default>` Overrides the default value of the property in-editor that appears as a hint in the property's UI.
 /// - `title = "<string>"` Sets the title of the property, in-editor it looks like `property_name (Property Title)`.
 #[proc_macro_attribute]
 pub fn solid_class(attr: proc_macro::TokenStream, input: proc_macro::TokenStream) -> proc_macro::TokenStream {
@@ -71,7 +71,7 @@ pub fn solid_class(attr: proc_macro::TokenStream, input: proc_macro::TokenStream
 /// - `must_set` Use on fields you want to output an error if not defined, rather than just being replaced by the field's default value.
 /// - `ignore` Don't include this field in-editor. Sets to default value on spawn.
 /// - `rename = "<name>"` Renames this field in-editor.
-/// - `default = "<default string>"` Overrides the default value of the property in-editor that appears as a hint in the property's UI.
+/// - `default = <default>` Overrides the default value of the property in-editor that appears as a hint in the property's UI.
 /// - `title = "<string>"` Sets the title of the property, in-editor it looks like `property_name (Property Title)`.
 #[proc_macro_attribute]
 pub fn base_class(attr: proc_macro::TokenStream, input: proc_macro::TokenStream) -> proc_macro::TokenStream {

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -6,6 +6,8 @@ use proc_macro2::*;
 use quote::*;
 use syn::*;
 
+// We repeat attributes for the convenience of the user so they don't have to go and look at the manual.
+
 /// Point classes don't have any geometry built in -- simply a point in space.
 ///
 /// # Type attributes
@@ -20,8 +22,12 @@ use syn::*;
 /// - `base(<type ...>)` Adds base classes to inherit.
 /// - `hooks(<SpawnHooks expression>)` Functions to run inside the spawn function of this class. Use for things like spawning models.
 ///
-/// # Field attributes
-/// - `#[must_set]` Use on fields you want to output an error if not defined, rather than just being replaced by the field's default value.
+/// # Field attributes (`#[class(...)]`)
+/// - `must_set` Use on fields you want to output an error if not defined, rather than just being replaced by the field's default value.
+/// - `ignore` Don't include this field in-editor. Sets to default value on spawn.
+/// - `rename = "<name>"` Renames this field in-editor.
+/// - `default = "<default string>"` Overrides the default value of the property in-editor that appears as a hint in the property's UI.
+/// - `title = "<string>"` Sets the title of the property, in-editor it looks like `property_name (Property Title)`.
 #[proc_macro_attribute]
 pub fn point_class(attr: proc_macro::TokenStream, input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 	quake_class::class_attribute(attr.into(), input.into(), quake_class::QuakeClassType::Point).into()
@@ -36,8 +42,12 @@ pub fn point_class(attr: proc_macro::TokenStream, input: proc_macro::TokenStream
 /// - `base(<type ...>)` Adds base classes to inherit.
 /// - `hooks(<SpawnHooks expression>)` Functions to run inside the spawn function of this class. Use for things like adding colliders.
 ///
-/// # Field attributes
-/// - `#[must_set]` Use on fields you want to output an error if not defined, rather than just being replaced by the field's default value.
+/// # Field attributes (`#[class(...)]`)
+/// - `must_set` Use on fields you want to output an error if not defined, rather than just being replaced by the field's default value.
+/// - `ignore` Don't include this field in-editor. Sets to default value on spawn.
+/// - `rename = "<name>"` Renames this field in-editor.
+/// - `default = "<default string>"` Overrides the default value of the property in-editor that appears as a hint in the property's UI.
+/// - `title = "<string>"` Sets the title of the property, in-editor it looks like `property_name (Property Title)`.
 #[proc_macro_attribute]
 pub fn solid_class(attr: proc_macro::TokenStream, input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 	quake_class::class_attribute(attr.into(), input.into(), quake_class::QuakeClassType::Solid).into()
@@ -45,7 +55,24 @@ pub fn solid_class(attr: proc_macro::TokenStream, input: proc_macro::TokenStream
 
 /// Base classes don't appear in-editor, rather they give properties and attributes to their sub-classes (components that require them).
 ///
-/// It has the same attributes as [`macro@point_class`].
+/// # Type attributes
+/// - `model(<path expression>)` Displays the entity as the specified model in-editor.
+/// - `model({ "path": <path expr>, "skin": <skin expr>, "frame": <frame expr>, "scale": <scale expr> })` Same as above attribute, but with greater control over how the model is shown. Note that any of these properties can be left out.
+/// - `color(<red> <green> <blue>)` Changes the wireframe color of the entity. Each number has a range from 0 to 255.
+/// - `iconsprite(...)]` Alias for `model`. When this or `model` is set to an image, it displays the entity as said image, presented as a billboard (always facing the camera).
+/// - `size(<-x> <-y> <-z>, <+x> <+y> <+z>)` The bounding box of the entity in-editor.
+/// - `classname(<case type>)` Case type can be something like `PascalCase` or `snake_case`. Default if not specified is `snake_case`.
+/// - `classname(<string>)` When outputted to fgd, use the specified string instead of a classname with case converted via the previous attribute.
+/// - `group(<string>)` Prefixes `<string>_` to your classname to avoid namespace stuttering.
+/// - `base(<type ...>)` Adds base classes to inherit.
+/// - `hooks(<SpawnHooks expression>)` Functions to run inside the spawn function of this class. Use for things like spawning models.
+///
+/// # Field attributes (`#[class(...)]`)
+/// - `must_set` Use on fields you want to output an error if not defined, rather than just being replaced by the field's default value.
+/// - `ignore` Don't include this field in-editor. Sets to default value on spawn.
+/// - `rename = "<name>"` Renames this field in-editor.
+/// - `default = "<default string>"` Overrides the default value of the property in-editor that appears as a hint in the property's UI.
+/// - `title = "<string>"` Sets the title of the property, in-editor it looks like `property_name (Property Title)`.
 #[proc_macro_attribute]
 pub fn base_class(attr: proc_macro::TokenStream, input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 	quake_class::class_attribute(attr.into(), input.into(), quake_class::QuakeClassType::Base).into()

--- a/src/class/builtin/base/bsp.rs
+++ b/src/class/builtin/base/bsp.rs
@@ -371,7 +371,7 @@ pub enum DirtMode {
 #[reflect(Default, Serialize, Deserialize)]
 pub struct BspExternalMap {
 	/// Specifies the filename of the .map to import.
-	#[must_set]
+	#[class(must_set)]
 	pub _external_map: String,
 
 	/// What entity you want the external map to turn in to.


### PR DESCRIPTION
Moves the existing `#[must_use]` attribute to `#[class(must_set)]`, along with
- `ignore`
- `rename = "<name>"`
- `default = <default>`
- `title = "<string>"`

See manual for more details.