### PR TITLE
Make cuboid brushes use cuboid colliders instead of convex colliders.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "ab_glyph"
-version = "0.2.30"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0f4f6fbdc5ee39f2ede9f5f3ec79477271a6d6a2baff22310d51736bda6cea"
+checksum = "e074464580a518d16a7126262fffaaa47af89d4099d4cb403f8ed938ba12ee7d"
 dependencies = [
  "ab_glyph_rasterizer",
  "owned_ttf_parser",
@@ -314,9 +314,9 @@ dependencies = [
 
 [[package]]
 name = "async-fs"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebcd09b382f40fcd159c2d695175b2ae620ffa5f3bd6f664131efff4e8b9e04a"
+checksum = "09f7e37c0ed80b2a977691c47dae8625cfb21e205827106c64f7c588766b2e50"
 dependencies = [
  "async-lock",
  "blocking",
@@ -325,9 +325,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1237c0ae75a0f3765f58910ff9cdd0a12eeb39ab2f4c7de23262f337f0aacbb3"
+checksum = "19634d6336019ef220f09fd31168ce5c184b295cbf80345437cc36094ef223ca"
 dependencies = [
  "async-lock",
  "cfg-if",
@@ -338,8 +338,7 @@ dependencies = [
  "polling",
  "rustix 1.0.8",
  "slab",
- "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -366,9 +365,9 @@ dependencies = [
 
 [[package]]
 name = "async-process"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde3f4e40e6021d7acffc90095cbd6dc54cb593903d1de5832f435eb274b85dc"
+checksum = "65daa13722ad51e6ab1a1b9c01299142bc75135b337923cfa10e79bbbd669f00"
 dependencies = [
  "async-channel",
  "async-io",
@@ -380,14 +379,13 @@ dependencies = [
  "event-listener",
  "futures-lite",
  "rustix 1.0.8",
- "tracing",
 ]
 
 [[package]]
 name = "async-signal"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7605a4e50d4b06df3898d5a70bf5fde51ed9059b0434b73105193bc27acce0d"
+checksum = "f567af260ef69e1d52c2b560ce0ea230763e6fbb9214a85d768760a920e3e3c1"
 dependencies = [
  "async-io",
  "async-lock",
@@ -398,7 +396,7 @@ dependencies = [
  "rustix 1.0.8",
  "signal-hook-registry",
  "slab",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1101,9 +1099,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_materialize"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "470cddafb1300764af1232066b9733b3528524fa45195fd6d63765f2c12eba43"
+checksum = "d23ed413a9a1d205a4dc25959b111e0531584d205c74823962d44b126284aae8"
 dependencies = [
  "bevy",
  "serde",
@@ -1575,7 +1573,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smol",
- "strum 0.27.1",
+ "strum 0.27.2",
  "thiserror 2.0.12",
  "wgpu-types",
 ]
@@ -1861,9 +1859,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.9.3"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ecc273b49b3205b83d648f0690daa588925572cc5063745bfe547fe7ec8e1a1"
+checksum = "441473f2b4b0459a68628c744bc61d23e730fb00128b841d30fa4bb3972257e4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1916,9 +1914,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.29"
+version = "1.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
+checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
 dependencies = [
  "jobserver",
  "libc",
@@ -1975,9 +1973,9 @@ dependencies = [
 
 [[package]]
 name = "clipboard-win"
-version = "5.4.0"
+version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15efe7a882b08f34e38556b14f2fb3daa98769d06c7f0c1b076dfd0d983bc892"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
 dependencies = [
  "error-code",
 ]
@@ -2036,9 +2034,9 @@ checksum = "32b13ea120a812beba79e34316b3942a857c86ec1593cb34f27bb28272ce2cca"
 
 [[package]]
 name = "const_panic"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2459fc9262a1aa204eb4b5764ad4f189caec88aea9634389c0a25f8be7f6265e"
+checksum = "b98d1483e98c9d67f341ab4b3915cfdc54740bd6f5cccc9226ee0535d86aa8fb"
 
 [[package]]
 name = "const_soft_float"
@@ -3452,13 +3450,13 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638"
+checksum = "4488594b9328dee448adb906d8b126d9b7deb7cf5c22161ee591610bb1be83c0"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
- "redox_syscall 0.5.13",
+ "redox_syscall 0.5.14",
 ]
 
 [[package]]
@@ -4313,7 +4311,7 @@ checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.13",
+ "redox_syscall 0.5.14",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -4491,17 +4489,16 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.8.0"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b53a684391ad002dd6a596ceb6c74fd004fdce75f4be2e3f615068abbea5fd50"
+checksum = "8ee9b2fa7a4517d2c91ff5bc6c297a427a96749d15f98fcdbb22c05571a4d4b7"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
  "rustix 1.0.8",
- "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4635,7 +4632,7 @@ dependencies = [
  "qbsp_macros",
  "serde",
  "smallvec",
- "strum 0.27.1",
+ "strum 0.27.2",
  "texture_packer",
  "thiserror 2.0.12",
 ]
@@ -4887,9 +4884,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.13"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
+checksum = "de3a5d9f0aba1dbcec1cc47f0ff94a4b778fe55bca98a6dfa92e4e094e57b1c4"
 dependencies = [
  "bitflags 2.9.1",
 ]
@@ -5148,9 +5145,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
 dependencies = [
  "itoa",
  "memchr",
@@ -5392,11 +5389,11 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros 0.27.1",
+ "strum_macros 0.27.2",
 ]
 
 [[package]]
@@ -5414,14 +5411,13 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "rustversion",
  "syn",
 ]
 

--- a/src/brush.rs
+++ b/src/brush.rs
@@ -181,7 +181,40 @@ impl Brush {
 
 /// A 3D convex hull made of [`BrushPlane`]s (half-spaces).
 pub trait ConvexHull {
+	fn plane_count(&self) -> usize;
 	fn planes(&self) -> impl Iterator<Item = &BrushPlane> + Clone;
+
+	/// If this brush represents a cuboid, not a more complex shape, this will return [`Some`] with a `from` and `to` vector respectively.
+	fn as_cuboid(&self) -> Option<(DVec3, DVec3)> {
+		if self.plane_count() != 6 {
+			return None;
+		}
+
+		let mut from = DVec3::INFINITY;
+		let mut to = DVec3::NEG_INFINITY;
+
+		const MARGIN: f64 = 1e-8;
+		for plane in self.planes() {
+			// Surfaces face inwards, so for example +Y will represent the bottom of the cuboid.
+			if plane.normal.almost_eq(DVec3::Y, MARGIN) {
+				to.y = -plane.distance;
+			} else if plane.normal.almost_eq(DVec3::NEG_Y, MARGIN) {
+				from.y = plane.distance;
+			} else if plane.normal.almost_eq(DVec3::X, MARGIN) {
+				to.x = -plane.distance;
+			} else if plane.normal.almost_eq(DVec3::NEG_X, MARGIN) {
+				from.x = plane.distance;
+			} else if plane.normal.almost_eq(DVec3::Z, MARGIN) {
+				to.z = -plane.distance;
+			} else if plane.normal.almost_eq(DVec3::NEG_Z, MARGIN) {
+				from.z = plane.distance;
+			} else {
+				return None;
+			}
+		}
+
+		if from.is_finite() && to.is_finite() { Some((from, to)) } else { None }
+	}
 
 	/// Returns `true` if `point` is not on the outside of the brush, else `false`.
 	fn contains_point(&self, point: DVec3) -> bool {
@@ -233,6 +266,11 @@ pub trait ConvexHull {
 }
 
 impl ConvexHull for Brush {
+	#[inline]
+	fn plane_count(&self) -> usize {
+		self.surfaces.len()
+	}
+
 	#[inline]
 	fn planes(&self) -> impl Iterator<Item = &BrushPlane> + Clone {
 		self.surfaces.iter().map(|surface| &surface.plane)

--- a/src/bsp/mod.rs
+++ b/src/bsp/mod.rs
@@ -75,6 +75,11 @@ pub struct BspBrush {
 
 impl ConvexHull for BspBrush {
 	#[inline]
+	fn plane_count(&self) -> usize {
+		self.planes.len()
+	}
+
+	#[inline]
 	fn planes(&self) -> impl Iterator<Item = &BrushPlane> + Clone {
 		self.planes.iter()
 	}

--- a/src/physics.rs
+++ b/src/physics.rs
@@ -7,7 +7,7 @@ use geometry::{BrushList, Brushes};
 #[cfg(feature = "rapier")]
 use bevy_rapier3d::math::Vect as Vector;
 #[cfg(feature = "rapier")]
-use bevy_rapier3d::prelude::*;
+use bevy_rapier3d::{parry::shape::SharedShape, prelude::*};
 /// Simplified version of Avian's trait by the same name because as far as i can tell, bevy_rapier3d doesn't support f64.
 #[cfg(feature = "rapier")]
 trait AdjustPrecision: Sized {
@@ -34,6 +34,7 @@ impl AdjustPrecision for Vec3 {
 #[cfg(feature = "avian")]
 use avian3d::{
 	math::{AdjustPrecision, Vector},
+	parry::shape::SharedShape,
 	prelude::*,
 };
 
@@ -49,18 +50,27 @@ pub struct ConvexCollision;
 #[reflect(Component)]
 pub struct TrimeshCollision;
 
-pub type BrushVertices = Vec<Vector>;
+enum ConvexPhysicsGeometry {
+	ConvexHull(Vec<Vector>),
+	Cuboid { center: Vector, half_extents: Vector },
+}
 
 /// Attempts to calculate vertices on the brushes contained within for use in physics, if it can find said brushes.
 ///
 /// If it can't find them (like if the asset isn't loaded), returns [`None`].
-pub fn calculate_brushes_vertices<'l, 'w: 'l>(
+fn calculate_convex_physics_geometry<'l, 'w: 'l>(
 	brushes: &Brushes,
 	brush_lists: &'w Assets<BrushList>,
 	#[cfg(feature = "bsp")] bsp_brushes: &'w Assets<BspBrushesAsset>,
-) -> Option<Vec<BrushVertices>> {
-	fn extract_vertices<T: ConvexHull>(brush: &T) -> Vec<Vector> {
-		brush.calculate_vertices().map(|(position, _)| position.adjust_precision()).collect()
+) -> Option<Vec<ConvexPhysicsGeometry>> {
+	fn extract_vertices<T: ConvexHull>(brush: &T) -> ConvexPhysicsGeometry {
+		match brush.as_cuboid() {
+			Some((from, to)) => ConvexPhysicsGeometry::Cuboid {
+				center: (0.5 * (from + to)).adjust_precision(),
+				half_extents: (0.5 * (to - from)).adjust_precision(),
+			},
+			None => ConvexPhysicsGeometry::ConvexHull(brush.calculate_vertices().map(|(position, _)| position.adjust_precision()).collect()),
+		}
 	}
 
 	match brushes {
@@ -103,7 +113,7 @@ impl PhysicsPlugin {
 		#[allow(unused)]
 		for (entity, brushes, transform) in &query {
 			let mut colliders = Vec::new();
-			let Some(brush_vertices) = calculate_brushes_vertices(
+			let Some(brush_geometries) = calculate_convex_physics_geometry(
 				brushes,
 				&brush_lists,
 				#[cfg(feature = "bsp")]
@@ -112,41 +122,52 @@ impl PhysicsPlugin {
 				continue;
 			};
 
-			for (brush_idx, mut vertices) in brush_vertices.into_iter().enumerate() {
-				if vertices.is_empty() {
-					continue;
-				}
+			for (brush_idx, physics_geometry) in brush_geometries.into_iter().enumerate() {
+				match physics_geometry {
+					ConvexPhysicsGeometry::Cuboid { center, half_extents } => {
+						colliders.push((
+							center,
+							transform.rotation.inverse(),
+							SharedShape::cuboid(half_extents.x, half_extents.y, half_extents.z).into(),
+						));
+					}
 
-				// Bring the vertices to the origin if they're generated in world-space (non-bsp)
-				#[cfg(feature = "bsp")]
-				let is_bsp = matches!(brushes, Brushes::Bsp(_));
-				#[cfg(not(feature = "bsp"))]
-				let is_bsp = false;
-				if !is_bsp {
-					for vertex in &mut vertices {
-						// *vertex = transform.rotation.inverse() * (*vertex - transform.translation) + transform.translation;
-						*vertex -= transform.translation.adjust_precision();
+					ConvexPhysicsGeometry::ConvexHull(mut vertices) => {
+						if vertices.is_empty() {
+							continue;
+						}
+
+						// Bring the vertices to the origin if they're generated in world-space (non-bsp)
+						#[cfg(feature = "bsp")]
+						if !matches!(brushes, Brushes::Bsp(_)) {
+							for vertex in &mut vertices {
+								*vertex -= transform.translation.adjust_precision();
+							}
+						}
+
+						macro_rules! fail {
+							() => {
+								error!(
+									"Entity {entity}'s brush (index {brush_idx}) is invalid (non-convex), and a collider could not be computed for it!"
+								);
+								continue;
+							};
+						}
+
+						#[cfg(feature = "avian")]
+						let Some(collider) = Collider::convex_hull(vertices) else {
+							fail!();
+						};
+
+						// bevy_rapier3d::geometry::Collider::cub
+						#[cfg(feature = "rapier")]
+						let Some(collider) = Collider::convex_hull(&vertices) else {
+							fail!();
+						};
+
+						colliders.push((Vector::ZERO, transform.rotation.inverse(), collider));
 					}
 				}
-
-				macro_rules! fail {
-					() => {
-						error!("Entity {entity}'s brush (index {brush_idx}) is invalid (non-convex), and a collider could not be computed for it!");
-						continue;
-					};
-				}
-
-				#[cfg(feature = "avian")]
-				let Some(collider) = Collider::convex_hull(vertices) else {
-					fail!();
-				};
-
-				#[cfg(feature = "rapier")]
-				let Some(collider) = Collider::convex_hull(&vertices) else {
-					fail!();
-				};
-
-				colliders.push((Vector::ZERO, transform.rotation.inverse(), collider));
 			}
 
 			if colliders.is_empty() {


### PR DESCRIPTION
Cuboid brushes don't need convex hull colliders to represent them, and as far as I know cuboid colliders are more numerically stable, so this uses cuboid colliders is the brush is perfectly cuboid.