### PR TITLE
Support for unary expression values in `[number_key]` enum discrimants.

### DIFF
--- a/src/fgd.rs
+++ b/src/fgd.rs
@@ -532,4 +532,27 @@ mod tests {
 		assert_eq!(f32::fgd_parse("3,120").unwrap(), 3.120);
 		assert_eq!(f64::fgd_parse("300.100,25").unwrap(), 300100.25);
 	}
+
+	#[test]
+	fn unary_prefixed_enum_values() {
+		/// Handle simple integer expressions in [number_key].
+		///
+		#[derive(FgdType, Debug, Clone, PartialEq)]
+		#[number_key]
+		enum TestEnum {
+			/// First value.
+			A = 0,
+			/// Second value.
+			B = 0x123,
+			/// Third value.
+			C = -1000,
+			/// Fourth value.
+			D = !0x1,
+		}
+
+		assert_eq!(0, TestEnum::A as i32);
+		assert_eq!(0x123, TestEnum::B as i32);
+		assert_eq!(-1000, TestEnum::C as i32);
+		assert_eq!(-2, TestEnum::D as i32);
+	}
 }


### PR DESCRIPTION
I wanted to use negative values in one of my `FgdType` enums, as the `i32` promises, but couldn't find any way around it since these aren't treated as raw constants, but as `UnaryExpr`s.

I looked briefly for functionality in `syn` to evaluate expression trees, but no dice, and didn't want to bring in a lot of other features or crates, so this just evaluates the easy cases of unary expressions, thus covering `-n` and `!n`. 

