### PR TITLE
Rename spawn hooks to scene hooks

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -149,9 +149,9 @@ struct MyPointClass;
 ```
 
 ### ***Attribute: `hooks`***
-This attribute requires a Rust expression that produces a `SpawnHooks` instance. If this attribute isn't specified, it uses the default spawn hooks defined in [`TrenchBroomConfig`](bevy_trenchbroom::config::TrenchBroomConfig).
+This attribute requires a Rust expression that produces a `SceneHooks` instance. If this attribute isn't specified, it uses the default scene hooks defined in [`TrenchBroomConfig`](bevy_trenchbroom::config::TrenchBroomConfig).
 
-[`SpawnHooks`](bevy_trenchbroom::class::spawn_hooks::SpawnHooks) is a struct containing a list of functions to be called in the [scene world](#loading-maps) when an entity spawns, provided with [context](bevy_trenchbroom::class::QuakeClassSpawnView) for the spawn.
+[`SceneHooks`](bevy_trenchbroom::class::scene_hooks::SceneHooks) is a struct containing a list of functions to be called in the [scene world](#loading-maps) when an entity spawns, provided with [context](bevy_trenchbroom::class::QuakeClassSpawnView) for the spawn.
 
 Examples:
 ```rust
@@ -161,7 +161,7 @@ Examples:
 // When creating your App...
 TrenchBroomPlugins(
 	TrenchBroomConfig::new("example")
-		.default_solid_spawn_hooks(|| SpawnHooks::new().smooth_by_default_angle())
+		.default_solid_scene_hooks(|| SceneHooks::new().smooth_by_default_angle())
 		// The above call will make slightly angled brush faces have
 		// interpolated normals, allowing smooth curves in geometry.
 		// If you're using a physics engine integration, this is
@@ -171,13 +171,13 @@ TrenchBroomPlugins(
 # ;
 // ...
 
-// Default solid class spawn hooks will be used.
+// Default solid class scene hooks will be used.
 #[solid_class]
 struct SolidClassA;
 
 #[solid_class(
 	// This overrides the above hooks. This geometry will not be smoothed.
-	hooks(SpawnHooks::new().push(Self::example_spawn_hook)),
+	hooks(SceneHooks::new().push(Self::example_spawn_hook)),
 )]
 struct SolidClassB;
 impl SolidClassB {
@@ -198,7 +198,7 @@ Some hooks are included by default, some you might be interested in are
 - `.convex_collider()` and `.trimesh_collider()` which add colliders if you have a physics engine integration enabled.
 - `.with(<bundle>)` and `.meshes_with(<bundle>)` if all you want to do is add components to the entity or its mesh entities.
 
-Hacky note: Because of the macro implementation, you technically have access to the [`QuakeClassSpawnView`](bevy_trenchbroom::class::QuakeClassSpawnView) variable called `view` when creating the spawn hooks instance, allowing you to extend default hooks through it. You probably shouldn't rely on this.
+Hacky note: Because of the macro implementation, you technically have access to the [`QuakeClassSpawnView`](bevy_trenchbroom::class::QuakeClassSpawnView) variable called `view` when creating the scene hooks instance, allowing you to extend default hooks through it. You probably shouldn't rely on this.
 
 ### ***Field Attribute: `must_set`***
 Use on fields you want to output an error if not defined, rather than just being replaced by the field's default value.
@@ -370,7 +370,7 @@ fn spawn_test_map(
 }
 ```
 
-`test.map` and `test.bsp` load `QuakeMap` and `Bsp` assets respectively. Both of these construct a ready-to-spawn scene when loaded, calling classes' spawn hooks in the loading process.
+`test.map` and `test.bsp` load `QuakeMap` and `Bsp` assets respectively. Both of these construct a ready-to-spawn scene when loaded, calling classes' scene hooks in the loading process.
 This scene is labeled "Scene" and can be retrieved with Bevy's `<path>#<label>` asset path syntax as the code above shows.
 
 TIP: For processes in the main world that depend on colliders (e.g. AI navigation mesh construction), observe the `SceneCollidersReady` rather than the `SceneInstanceReady` trigger.

--- a/Migration Guide.md
+++ b/Migration Guide.md
@@ -1,6 +1,7 @@
 # 0.10 to 0.11
 - The global spawner in `TrenchBroomConfig` has been split into `pre_spawn_hook` and `post_spawn_hook` for more granular control.
 - Quake 2 and GoldSrc BSP formats are now supported. If you are using BSPs, you should probably switch to the Quake 2 QBISM format, as it is a direct upgrade to BSP2. Check the [BSP section in the manual](https://docs.rs/bevy_trenchbroom/latest/bevy_trenchbroom/manual/index.html#bsp) for updated recommended command arguments.
+- Spawn hooks have been renamed into scene hooks to better represent where they are run.
 
 # 0.9 to 0.10
 - Physics integrations have been decoupled into the `bevy_trenchbroom_rapier` and `bevy_trenchbroom_avian` crates to make releasing updates quicker. Add one of those into your project, and add the plugin `TrenchBroomPhysicsPlugin::new(/*(physics engine)*/}PhysicsBackend)`.

--- a/example/bsp_loading/main.rs
+++ b/example/bsp_loading/main.rs
@@ -56,7 +56,7 @@ impl Cube {
 #[point_class(
 	model("models/mushroom.glb"),
 	size(-4 -4 0, 4 4 16),
-	hooks(SpawnHooks::new().spawn_class_gltf::<Self>()),
+	hooks(SceneHooks::new().spawn_class_gltf::<Self>()),
 )]
 pub struct Mushroom;
 

--- a/example/map_loading/main.rs
+++ b/example/map_loading/main.rs
@@ -34,7 +34,7 @@ impl Cube {
 #[point_class(
 	model("models/mushroom.glb"),
 	size(-4 -4 0, 4 4 16),
-	hooks(SpawnHooks::new().spawn_class_gltf::<Self>()),
+	hooks(SceneHooks::new().spawn_class_gltf::<Self>()),
 )]
 pub struct Mushroom;
 
@@ -69,7 +69,7 @@ fn main() {
 	// Unfortunately, due to Rust limitations on attributes, we have to build this through a variable.
 	#[allow(unused_mut)]
 	let mut trenchbroom_plugins = TrenchBroomPlugins(
-		TrenchBroomConfig::new("bevy_trenchbroom_example").default_solid_spawn_hooks(|| SpawnHooks::new().smooth_by_default_angle()),
+		TrenchBroomConfig::new("bevy_trenchbroom_example").default_solid_scene_hooks(|| SceneHooks::new().smooth_by_default_angle()),
 	)
 	.build()
 	// This is because we use a custom light class for parity with bsp_loading.

--- a/example/physics_avian/main.rs
+++ b/example/physics_avian/main.rs
@@ -20,7 +20,7 @@ fn main() {
 		.add_plugins(
 			TrenchBroomPlugins(
 				TrenchBroomConfig::new("bevy_trenchbroom_example")
-					.default_solid_spawn_hooks(|| SpawnHooks::new().convex_collider())
+					.default_solid_scene_hooks(|| SceneHooks::new().convex_collider())
 					.no_bsp_lighting(true),
 			)
 			.build()

--- a/readme.md
+++ b/readme.md
@@ -105,11 +105,11 @@ For more information, please see [the manual](https://docs.rs/bevy_trenchbroom/l
 `bevy_trenchbroom` supports [bevy_rapier3d](https://crates.io/crates/bevy_rapier3d) and [avian3d](https://crates.io/crates/avian3d) to easily add colliders when spawning geometry.
 
 First, add the `bevy_trenchbroom_rapier` or `bevy_trenchbroom_avian` integration crates, then add the plugin `TrenchBroomPhysicsPlugin::new(RapierPhysicsBackend)` or `TrenchBroomPhysicsPlugin::new(AvianPhysicsBackend)` respectively.
-Now you can either call `convex_collider` or `trimesh_collider` on your class's `SpawnHooks` to create the respective type of collider(s) with said geometry.
+Now you can either call `convex_collider` or `trimesh_collider` on your class's `SceneHooks` to create the respective type of collider(s) with said geometry.
 
 TIP: If you want Brush entities to have a collider by *default*, you can add this to your `TrenchBroomConfig`:
 ```rust ignore
-.default_solid_spawn_hooks(|| SpawnHooks::new().convex_collider())
+.default_solid_scene_hooks(|| SceneHooks::new().convex_collider())
 ```
 
 ## Multiplayer

--- a/src/class/builtin/light/basic_impls.rs
+++ b/src/class/builtin/light/basic_impls.rs
@@ -76,7 +76,7 @@ pub struct BakedOnlyLight;
 	base(MixedLight),
 	classname("light"),
 	iconsprite({ path: "sprites/light_point.png", scale: 0.1 }),
-	hooks(SpawnHooks::new().push(Self::spawn_hook)),
+	hooks(SceneHooks::new().push(Self::spawn_hook)),
 )]
 #[reflect(no_auto_register)]
 pub struct MapDynamicBspBakedLight;
@@ -106,7 +106,7 @@ pub struct MapDynamicBspBakedLight;
 	base(MixedLight),
 	classname("light"),
 	iconsprite({ path: "sprites/light_point.png", scale: 0.1 }),
-	hooks(SpawnHooks::new().push(Self::spawn_hook)),
+	hooks(SceneHooks::new().push(Self::spawn_hook)),
 )]
 #[reflect(no_auto_register)]
 pub struct CombinedLight;

--- a/src/class/mod.rs
+++ b/src/class/mod.rs
@@ -1,5 +1,5 @@
 pub mod builtin;
-pub mod spawn_hooks;
+pub mod scene_hooks;
 
 use bevy::{asset::LoadContext, platform::collections::HashSet};
 use bevy_reflect::{FromType, GetTypeRegistration, TypeRegistry};
@@ -260,7 +260,7 @@ impl ErasedQuakeClass {
 	}
 }
 
-/// Fully spawns a Quake entity into a scene through a [`QuakeClassSpawnView`], calling [`ErasedQuakeClass::spawn_fn`] recursively for all base classes, as well as pre and post spawn hooks.
+/// Fully spawns a Quake entity into a scene through a [`QuakeClassSpawnView`], calling [`ErasedQuakeClass::spawn_fn`] recursively for all base classes, as well as pre and post scene hooks.
 pub fn spawn_quake_entity_into_scene(view: &mut QuakeClassSpawnView) -> anyhow::Result<()> {
 	// We use string formatting because I am not a fan of anyhow's context adding system
 	(view.tb_config.pre_spawn_hook)(view).map_err(|err| anyhow!("pre_spawn_hook: {err}"))?;
@@ -350,7 +350,7 @@ mod tests {
 		static mut CLASS_CALLED: bool = false;
 
 		#[base_class(
-			hooks(SpawnHooks::new().push(|_| {
+			hooks(SceneHooks::new().push(|_| {
 				assert!(unsafe { !BASE_CALLED });
 				unsafe { BASE_CALLED = true; }
 				Ok(())
@@ -361,7 +361,7 @@ mod tests {
 
 		#[point_class(
 			base(Base, Base),
-			hooks(SpawnHooks::new().push(|_| {
+			hooks(SceneHooks::new().push(|_| {
 				assert!(unsafe { !CLASS_CALLED });
 				unsafe { CLASS_CALLED = true; }
 				Ok(())

--- a/src/class/scene_hooks.rs
+++ b/src/class/scene_hooks.rs
@@ -10,10 +10,10 @@ pub const DEFAULT_NORMAL_SMOOTH_THRESHOLD: f32 = std::f32::consts::FRAC_PI_4;
 
 /// Functions that occur during the spawning of an [`QuakeClass`] entity into a scene world.
 #[derive(Default)]
-pub struct SpawnHooks {
+pub struct SceneHooks {
 	pub hooks: Vec<Box<SpawnFnOnce>>,
 }
-impl SpawnHooks {
+impl SceneHooks {
 	pub fn new() -> Self {
 		Self::default()
 	}
@@ -228,7 +228,7 @@ impl SpawnHooks {
 	/// #[point_class(
 	///     model("models/mushroom.glb"),
 	///     size(-4 -4 0, 4 4 16),
-	///     hooks(SpawnHooks::new().spawn_class_gltf::<Self>()),
+	///     hooks(SceneHooks::new().spawn_class_gltf::<Self>()),
 	/// )]
 	/// pub struct Mushroom;
 	/// ```
@@ -236,7 +236,7 @@ impl SpawnHooks {
 		self.spawn_class_model_internal::<T>(Some("Scene0"))
 	}
 
-	/// Spawn hook that simply loads the path specified in the model, adding it to the map's asset dependencies.
+	/// Scene hook that simply loads the path specified in the model, adding it to the map's asset dependencies.
 	///
 	/// TODO: This currently only works for simple paths (e.g. `#[model("path/to/model")]`), more advanced uses of the `model` property won't work.
 	///
@@ -246,7 +246,7 @@ impl SpawnHooks {
 	/// # use bevy_trenchbroom::prelude::*;
 	/// #[point_class(
 	///     model("models/torch.glb"),
-	///     hooks(SpawnHooks::new().preload_model::<Self>()),
+	///     hooks(SceneHooks::new().preload_model::<Self>()),
 	/// )]
 	/// pub struct Torch;
 	/// ```
@@ -297,7 +297,7 @@ mod tests {
 
 		#[point_class(
 			model("models/mushroom.glb"),
-			hooks(SpawnHooks::new().preload_model::<Self>()),
+			hooks(SceneHooks::new().preload_model::<Self>()),
 		)]
 		#[component(on_add = Self::on_add)]
 		pub struct Mushroom;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -255,15 +255,15 @@ pub struct TrenchBroomConfig {
 	#[default(Hook(Arc::new(Self::default_post_spawn_hook)))]
 	pub post_spawn_hook: Hook<SpawnFn>,
 
-	/// Spawn hooks to run on solid classes unless overridden.
-	#[default(SpawnHooks::new)]
-	pub default_solid_spawn_hooks: fn() -> SpawnHooks,
-	/// Spawn hooks to run on point classes unless overridden.
-	#[default(SpawnHooks::new)]
-	pub default_point_spawn_hooks: fn() -> SpawnHooks,
-	/// Spawn hooks to run on base classes unless overridden.
-	#[default(SpawnHooks::new)]
-	pub default_base_spawn_hooks: fn() -> SpawnHooks,
+	/// Scene hooks to run on solid classes unless overridden.
+	#[default(SceneHooks::new)]
+	pub default_solid_scene_hooks: fn() -> SceneHooks,
+	/// Scene hooks to run on point classes unless overridden.
+	#[default(SceneHooks::new)]
+	pub default_point_scene_hooks: fn() -> SceneHooks,
+	/// Scene hooks to run on base classes unless overridden.
+	#[default(SceneHooks::new)]
+	pub default_base_scene_hooks: fn() -> SceneHooks,
 
 	/// Whether to apply the translation and rotation fields regardless of having [`Transform`] as a base class.
 	/// Adds convenance and removes a foot-gun, but is less flexible, hence why it is disableable.

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -39,7 +39,7 @@ pub use crate::{
 	class::{
 		QuakeClass, QuakeClassAppExt, ReflectQuakeClass,
 		builtin::{Target, Targetable},
-		spawn_hooks::*,
+		scene_hooks::*,
 	},
 	config::TrenchBroomConfig,
 	qmap::QuakeMapEntity,

--- a/subcrates/bevy_trenchbroom_macros/src/lib.rs
+++ b/subcrates/bevy_trenchbroom_macros/src/lib.rs
@@ -20,7 +20,7 @@ use syn::*;
 /// - `classname(<string>)` When outputted to fgd, use the specified string instead of a classname with case converted via the previous attribute.
 /// - `group(<string>)` Prefixes `<string>_` to your classname to avoid namespace stuttering.
 /// - `base(<type ...>)` Adds base classes to inherit.
-/// - `hooks(<SpawnHooks expression>)` Functions to run inside the spawn function of this class. Use for things like spawning models.
+/// - `hooks(<SceneHooks expression>)` Functions to run inside the spawn function of this class. Use for things like spawning models.
 ///
 /// # Field attributes (`#[class(...)]`)
 /// - `must_set` Use on fields you want to output an error if not defined, rather than just being replaced by the field's default value.
@@ -40,7 +40,7 @@ pub fn point_class(attr: proc_macro::TokenStream, input: proc_macro::TokenStream
 /// - `classname(<string>)` When outputted to fgd, use the specified string instead of a classname with case converted via the previous attribute.
 /// - `group(<string>)` Prefixes `<string>_` to your classname to avoid namespace stuttering.
 /// - `base(<type ...>)` Adds base classes to inherit.
-/// - `hooks(<SpawnHooks expression>)` Functions to run inside the spawn function of this class. Use for things like adding colliders.
+/// - `hooks(<SceneHooks expression>)` Functions to run inside the spawn function of this class. Use for things like adding colliders.
 ///
 /// # Field attributes (`#[class(...)]`)
 /// - `must_set` Use on fields you want to output an error if not defined, rather than just being replaced by the field's default value.
@@ -65,7 +65,7 @@ pub fn solid_class(attr: proc_macro::TokenStream, input: proc_macro::TokenStream
 /// - `classname(<string>)` When outputted to fgd, use the specified string instead of a classname with case converted via the previous attribute.
 /// - `group(<string>)` Prefixes `<string>_` to your classname to avoid namespace stuttering.
 /// - `base(<type ...>)` Adds base classes to inherit.
-/// - `hooks(<SpawnHooks expression>)` Functions to run inside the spawn function of this class. Use for things like spawning models.
+/// - `hooks(<SceneHooks expression>)` Functions to run inside the spawn function of this class. Use for things like spawning models.
 ///
 /// # Field attributes (`#[class(...)]`)
 /// - `must_set` Use on fields you want to output an error if not defined, rather than just being replaced by the field's default value.

--- a/subcrates/bevy_trenchbroom_macros/src/quake_class.rs
+++ b/subcrates/bevy_trenchbroom_macros/src/quake_class.rs
@@ -284,11 +284,11 @@ pub(super) fn class_attribute(attr: TokenStream, input: TokenStream, ty: QuakeCl
 	let size = option(opts.size.map(|size| size.to_string()));
 	let decal = opts.decal;
 
-	let spawn_hooks = match opts.hooks {
+	let scene_hooks = match opts.hooks {
 		None => match ty {
-			QuakeClassType::Base => quote! { (view.tb_config.default_base_spawn_hooks)() },
-			QuakeClassType::Point => quote! { (view.tb_config.default_point_spawn_hooks)() },
-			QuakeClassType::Solid => quote! { (view.tb_config.default_solid_spawn_hooks)() },
+			QuakeClassType::Base => quote! { (view.tb_config.default_base_scene_hooks)() },
+			QuakeClassType::Point => quote! { (view.tb_config.default_point_scene_hooks)() },
+			QuakeClassType::Solid => quote! { (view.tb_config.default_solid_scene_hooks)() },
 		},
 		Some(hooks) => hooks.to_token_stream(),
 	};
@@ -317,7 +317,7 @@ pub(super) fn class_attribute(attr: TokenStream, input: TokenStream, ty: QuakeCl
 				use ::bevy_trenchbroom::qmap::QuakeEntityErrorResultExt;
 				#spawn_constructor_default_value
 				view.world.entity_mut(view.entity).insert(#spawn_constructor);
-				let hooks: ::bevy_trenchbroom::class::spawn_hooks::SpawnHooks = #spawn_hooks;
+				let hooks: ::bevy_trenchbroom::class::scene_hooks::SceneHooks = #scene_hooks;
 				hooks.apply(view)?;
 				Ok(())
 			}


### PR DESCRIPTION
I feel like the name "spawn hooks" implies they do the same thing an `On<Add, ()>` observer does in the main world, rather than a function pointer run to build an entity in the scene hierarchy.
I considered renaming them to `SceneSpawnHooks` but I don't wanna type that :o